### PR TITLE
Update placeholder text in SettingsPage and remove API key validation…

### DIFF
--- a/src/app/[user]/[[...params]]/DiagramClientView.tsx
+++ b/src/app/[user]/[[...params]]/DiagramClientView.tsx
@@ -79,7 +79,9 @@ function DiagramClientView({
 
   // Sync editableCode with diagramCode when diagramCode changes
   useEffect(() => {
-    if (!showCodePanel) setEditableCode(displayDiagramCode);
+    if (!showCodePanel && editableCode !== displayDiagramCode) {
+      setEditableCode(displayDiagramCode);
+    }
   }, [displayDiagramCode, showCodePanel]);
 
   // Copy handlers

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -144,7 +144,7 @@ export default function SettingsPage() {
                   <div className="relative flex-1">
                     <Input 
                       type={showKey ? 'text' : 'password'} 
-                      placeholder="gza_..." 
+                      placeholder="Your API key..." 
                       value={apiKey}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
                       className="pr-10"

--- a/src/lib/trpc/routes/user.ts
+++ b/src/lib/trpc/routes/user.ts
@@ -4,7 +4,6 @@ import { db } from '@/db';
 import { userApiKeys, tokenUsage, userSubscriptions } from '@/db/schema';
 import { eq, and, gte, lte, desc } from 'drizzle-orm';
 import { encryptApiKey } from '@/lib/utils/encryption';
-import { TRPCError } from '@trpc/server';
 
 export const userRouter = router({
   // API Key Management

--- a/src/lib/trpc/routes/user.ts
+++ b/src/lib/trpc/routes/user.ts
@@ -3,7 +3,7 @@ import { router, protectedProcedure } from '@/lib/trpc/trpc';
 import { db } from '@/db';
 import { userApiKeys, tokenUsage, userSubscriptions } from '@/db/schema';
 import { eq, and, gte, lte, desc } from 'drizzle-orm';
-import { encryptApiKey, validateApiKey } from '@/lib/utils/encryption';
+import { encryptApiKey } from '@/lib/utils/encryption';
 import { TRPCError } from '@trpc/server';
 
 export const userRouter = router({
@@ -13,13 +13,6 @@ export const userRouter = router({
       apiKey: z.string().min(1, 'API key is required') 
     }))
     .mutation(async ({ input, ctx }) => {
-      if (!validateApiKey(input.apiKey)) {
-        throw new TRPCError({ 
-          code: 'BAD_REQUEST', 
-          message: 'Invalid Gemini API key format. Should start with "gza_"' 
-        });
-      }
-
       const encrypted = encryptApiKey(input.apiKey);
       
       await db.insert(userApiKeys).values({

--- a/src/lib/utils/encryption.ts
+++ b/src/lib/utils/encryption.ts
@@ -22,9 +22,4 @@ export function decryptApiKey(encryptedApiKey: string): string {
   decrypted += decipher.final('utf8');
   
   return decrypted;
-}
-
-export function validateApiKey(apiKey: string): boolean {
-  // Basic validation for Gemini API key format
-  return apiKey.startsWith('gza_') && apiKey.length > 10;
 } 


### PR DESCRIPTION
… function

- Changed the placeholder for the API key input field to "Your API key..." for improved clarity.
- Removed the `validateApiKey` function from the encryption utility as it was deemed unnecessary.
- Cleaned up code by eliminating unused imports and ensuring clarity throughout the changes.
- Marked off completed tasks in todos.md.