### PR TITLE
fix: rework private-repo install flow to stop killing retention

### DIFF
--- a/src/app/[user]/[[...params]]/RepoClientView.tsx
+++ b/src/app/[user]/[[...params]]/RepoClientView.tsx
@@ -43,6 +43,14 @@ function RepoClientViewInner({ user, repo, refName, path, files, isLoading, erro
     );
   }
 
+  if (error) {
+    return (
+      <div className="max-w-screen-xl w-full mx-auto px-2 sm:px-4 pt-2 sm:pt-4">
+        <RepoStatus error={{ message: String(error) }} owner={user} repo={repo} />
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-screen-xl w-full mx-auto px-2 sm:px-4 pt-2 sm:pt-4">
       {/* File Explorer Tab Button */}
@@ -76,7 +84,6 @@ function RepoClientViewInner({ user, repo, refName, path, files, isLoading, erro
         onClose={() => setIsFileExplorerOpen(false)}
       />
 
-      <RepoStatus error={error ? { message: String(error) } : null} />
     </div>
   );
 }

--- a/src/app/install/callback/page.tsx
+++ b/src/app/install/callback/page.tsx
@@ -27,7 +27,10 @@ function InstallCallbackContent() {
 
     if (setupAction === 'update') {
       setStatus('success');
-      setMessage('GitHub App updated successfully!');
+      const state = searchParams.get('state');
+      const target = state && state.startsWith('/') && !state.startsWith('//') ? state : null;
+      setMessage(target ? `Updated. Taking you back to ${target}...` : 'GitHub App updated successfully!');
+      if (target) setTimeout(() => router.push(target), 1500);
       return;
     }
 
@@ -69,7 +72,14 @@ function InstallCallbackContent() {
 
       if (response.ok) {
         setStatus('success');
-        setMessage('GitHub App installed and linked successfully! You can now access private repositories.');
+        const state = searchParams.get('state');
+        const target = state && state.startsWith('/') && !state.startsWith('//') ? state : null;
+        setMessage(target
+          ? `Installed. Taking you back to ${target}...`
+          : 'GitHub App installed. You can now access private repositories.');
+        if (target) {
+          setTimeout(() => router.push(target), 1500);
+        }
       } else {
         setStatus('error');
         setMessage(data.error || 'Failed to link installation. Please try again.');
@@ -92,7 +102,9 @@ function InstallCallbackContent() {
   };
 
   const handleContinue = () => {
-    router.push('/');
+    const state = searchParams.get('state');
+    const target = state && state.startsWith('/') && !state.startsWith('//') ? state : '/';
+    router.push(target);
   };
 
   const handleRetry = () => {
@@ -127,7 +139,11 @@ function InstallCallbackContent() {
         <CardContent className="text-center">
           {status === 'success' && (
             <Button onClick={handleContinue} className="w-full">
-              Continue to GG
+              {(() => {
+                const state = searchParams.get('state');
+                const target = state && state.startsWith('/') && !state.startsWith('//') ? state : null;
+                return target ? `Continue to ${target}` : 'Continue to github.gg';
+              })()}
             </Button>
           )}
           {status === 'needs-auth' && (

--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -1,154 +1,238 @@
 'use client';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Suspense, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
-import { CheckCircle, Shield, Zap, GitBranch } from 'lucide-react';
+import { useAuth } from '@/lib/auth/client';
+import { trpc } from '@/lib/trpc/client';
+import { ChevronDown, Eye, GitPullRequest, Lock, Github, Check, Settings } from 'lucide-react';
 
-export default function InstallPage() {
-  const handleInstall = () => {
-    const appName = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || 'gh-gg-dev';
-    const installUrl = `https://github.com/apps/${appName}/installations/new`;
-    window.open(installUrl, '_blank');
-  };
+const APP_NAME = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || 'gh-gg';
 
-  return (
-    <div className="min-h-screen bg-gray-50 py-12">
-      <div className="container mx-auto px-4 max-w-4xl">
-        <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            Install GitHub.gg App
-          </h1>
-          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Get enhanced repository analysis with access to private repositories, 
-            real-time webhooks, and automated insights.
-          </p>
-        </div>
+function buildInstallUrl(returnPath?: string | null) {
+  const base = `https://github.com/apps/${APP_NAME}/installations/new`;
+  return returnPath ? `${base}?state=${encodeURIComponent(returnPath)}` : base;
+}
 
-        <div className="grid md:grid-cols-2 gap-8 mb-12">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Shield className="h-5 w-5 text-blue-500" />
-                Secure & Private
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-2">
-                <li className="flex items-center gap-2">
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  Access to private repositories
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  No code or secrets exposed
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  GitHub App permissions only
-                </li>
-              </ul>
-            </CardContent>
-          </Card>
+function InstallContent() {
+  const searchParams = useSearchParams();
+  const { isSignedIn, isLoading: authLoading, signIn } = useAuth();
+  const [showPermissions, setShowPermissions] = useState(false);
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Zap className="h-5 w-5 text-yellow-500" />
-                Enhanced Features
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-2">
-                <li className="flex items-center gap-2">
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  Real-time analysis on pushes
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  Automated PR comments
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  Higher rate limits (5,000 req/hr)
-                </li>
-              </ul>
-            </CardContent>
-          </Card>
-        </div>
+  const returnTo = useMemo(() => {
+    const raw = searchParams.get('state') || searchParams.get('returnTo');
+    if (raw && raw.startsWith('/') && !raw.startsWith('//')) return raw;
+    return null;
+  }, [searchParams]);
 
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle>Permissions Required</CardTitle>
-            <CardDescription>
-              The GitHub App needs these permissions to provide enhanced analysis:
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 gap-4">
-              <div>
-                <h4 className="font-semibold mb-2">Repository Permissions</h4>
-                <div className="space-y-1">
-                  <Badge variant="secondary">Contents: Read-only</Badge>
-                  <Badge variant="secondary">Metadata: Read-only</Badge>
-                  <Badge variant="secondary">Pull requests: Read & write</Badge>
-                  <Badge variant="secondary">Issues: Read & write</Badge>
-                  <Badge variant="secondary">Commit statuses: Read & write</Badge>
-                </div>
-              </div>
-              <div>
-                <h4 className="font-semibold mb-2">Events</h4>
-                <div className="space-y-1">
-                  <Badge variant="outline">Push</Badge>
-                  <Badge variant="outline">Pull request</Badge>
-                  <Badge variant="outline">Installation</Badge>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+  const installUrl = buildInstallUrl(returnTo);
 
-        <div className="text-center">
-          <Button 
-            onClick={handleInstall} 
-            size="lg" 
-            className="text-lg px-8 py-4"
-          >
-            <GitBranch className="mr-2 h-5 w-5" />
-            Install GitHub.gg App
+  const installationQuery = trpc.webhooks.getInstallationInfo.useQuery(undefined, {
+    enabled: isSignedIn,
+  });
+
+  if (authLoading) {
+    return <Skeleton />;
+  }
+
+  if (!isSignedIn) {
+    return (
+      <Layout>
+        <Hero
+          title="Sign in to connect GitHub"
+          subtitle={
+            returnTo
+              ? `Sign in to unlock ${returnTo} and analyze your private repositories.`
+              : 'Sign in with GitHub to connect your account and analyze private repositories.'
+          }
+        />
+        <div className="mt-8 flex justify-center">
+          <Button size="lg" onClick={() => signIn(returnTo || '/install')} className="text-base px-6 py-6">
+            <Github className="mr-2 h-5 w-5" />
+            Sign in with GitHub
           </Button>
-          <p className="text-sm text-gray-500 mt-4">
-            You&apos;ll be redirected to GitHub to complete the installation
-          </p>
+        </div>
+      </Layout>
+    );
+  }
+
+  const installed = !!installationQuery.data;
+  const manageUrl = installed && installationQuery.data
+    ? `https://github.com/settings/installations/${installationQuery.data.installationId}`
+    : null;
+
+  if (installed && installationQuery.data) {
+    return (
+      <Layout>
+        <Hero
+          title="GitHub is connected"
+          subtitle={`github.gg has access to repos on ${installationQuery.data.accountLogin || 'your account'}.`}
+        />
+
+        <div className="mt-8 p-4 bg-green-50 border border-green-200 rounded-lg flex items-center gap-3">
+          <Check className="h-5 w-5 text-green-600 shrink-0" />
+          <div className="text-sm text-green-900">
+            Connection active. You can access your private repos now.
+          </div>
         </div>
 
-        <div className="mt-12 text-center">
-          <h3 className="text-lg font-semibold mb-4">What happens after installation?</h3>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div className="text-center">
-              <div className="bg-blue-100 rounded-full w-12 h-12 flex items-center justify-center mx-auto mb-3">
-                <span className="text-blue-600 font-bold">1</span>
+        <div className="mt-6 flex flex-wrap gap-3 justify-center">
+          {returnTo ? (
+            <Link href={returnTo}>
+              <Button size="lg">Continue to {returnTo}</Button>
+            </Link>
+          ) : (
+            <Link href="/">
+              <Button size="lg">Go to dashboard</Button>
+            </Link>
+          )}
+          {manageUrl && (
+            <a href={manageUrl} target="_blank" rel="noopener noreferrer">
+              <Button variant="outline" size="lg">
+                <Settings className="mr-2 h-4 w-4" />
+                Manage repositories on GitHub
+              </Button>
+            </a>
+          )}
+        </div>
+      </Layout>
+    );
+  }
+
+  // Signed in, not installed
+  return (
+    <Layout>
+      <Hero
+        title="Connect your GitHub account"
+        subtitle={
+          returnTo
+            ? `Connect GitHub to unlock ${returnTo} and any other private repos you want analyzed.`
+            : 'Connect GitHub to analyze your private repos, generate developer insights, and enable automated PR reviews.'
+        }
+      />
+
+      <div className="mt-8 space-y-3">
+        <ValueProp
+          icon={<Lock className="h-5 w-5 text-blue-600" />}
+          title="Read-only code access"
+          body="We read your code to generate analysis. We never store source code."
+        />
+        <ValueProp
+          icon={<Eye className="h-5 w-5 text-purple-600" />}
+          title="Private repo insights"
+          body="Scorecards, AI wikis, Developer Arena rankings — unlocked for your private repos."
+        />
+        <ValueProp
+          icon={<GitPullRequest className="h-5 w-5 text-green-600" />}
+          title="Automated PR reviews"
+          body="Optional: post AI code reviews as comments on your pull requests."
+        />
+      </div>
+
+      <div className="mt-8 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <div className="text-sm text-blue-900 leading-relaxed">
+          <span className="font-semibold">Tip:</span> On the next screen, GitHub will default to <em>All repositories</em>. You can choose <span className="font-semibold">Only select repositories</span> and pick just the repos you want analyzed.
+        </div>
+      </div>
+
+      <div className="mt-8 flex flex-col items-center gap-2">
+        <a href={installUrl} className="w-full max-w-sm">
+          <Button size="lg" className="w-full text-base py-6">
+            <Github className="mr-2 h-5 w-5" />
+            Connect GitHub Account
+          </Button>
+        </a>
+        <p className="text-xs text-gray-500">You&apos;ll be taken to GitHub to finish connecting.</p>
+      </div>
+
+      <Collapsible open={showPermissions} onOpenChange={setShowPermissions} className="mt-8">
+        <CollapsibleTrigger className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 transition-colors mx-auto">
+          <ChevronDown
+            className="h-3 w-3 transition-transform"
+            style={{ transform: showPermissions ? 'rotate(180deg)' : undefined }}
+          />
+          {showPermissions ? 'Hide' : 'View'} technical permissions
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-3">
+          <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg text-xs text-gray-600 space-y-3">
+            <div>
+              <div className="font-semibold text-gray-700 mb-2">Repository permissions</div>
+              <div className="flex flex-wrap gap-1.5">
+                <Badge variant="secondary">Contents: Read-only</Badge>
+                <Badge variant="secondary">Metadata: Read-only</Badge>
+                <Badge variant="secondary">Pull requests: Read &amp; write</Badge>
+                <Badge variant="secondary">Issues: Read &amp; write</Badge>
+                <Badge variant="secondary">Commit statuses: Read &amp; write</Badge>
               </div>
-              <h4 className="font-medium">Install App</h4>
-              <p className="text-sm text-gray-600">Choose repositories to grant access</p>
             </div>
-            <div className="text-center">
-              <div className="bg-blue-100 rounded-full w-12 h-12 flex items-center justify-center mx-auto mb-3">
-                <span className="text-blue-600 font-bold">2</span>
+            <div>
+              <div className="font-semibold text-gray-700 mb-2">Subscribed events</div>
+              <div className="flex flex-wrap gap-1.5">
+                <Badge variant="outline">Push</Badge>
+                <Badge variant="outline">Pull request</Badge>
+                <Badge variant="outline">Installation</Badge>
               </div>
-              <h4 className="font-medium">Webhook Setup</h4>
-              <p className="text-sm text-gray-600">Receive real-time repository events</p>
             </div>
-            <div className="text-center">
-              <div className="bg-blue-100 rounded-full w-12 h-12 flex items-center justify-center mx-auto mb-3">
-                <span className="text-blue-600 font-bold">3</span>
-              </div>
-              <h4 className="font-medium">Enhanced Analysis</h4>
-              <p className="text-sm text-gray-600">Get insights on pushes and PRs</p>
+            <div className="text-[11px] text-gray-500 pt-1">
+              Read &amp; write on PRs and issues is required to post AI review comments. You can disable PR reviews later in Settings.
             </div>
           </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </Layout>
+  );
+}
+
+function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gray-50 py-16">
+      <div className="container mx-auto px-4 max-w-xl">{children}</div>
+    </div>
+  );
+}
+
+function Hero({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="text-center">
+      <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">{title}</h1>
+      <p className="text-base text-gray-600 max-w-lg mx-auto leading-relaxed">{subtitle}</p>
+    </div>
+  );
+}
+
+function ValueProp({ icon, title, body }: { icon: React.ReactNode; title: string; body: string }) {
+  return (
+    <div className="flex gap-3 p-3">
+      <div className="shrink-0 mt-0.5">{icon}</div>
+      <div>
+        <div className="font-medium text-gray-900 text-sm">{title}</div>
+        <div className="text-sm text-gray-600 leading-relaxed">{body}</div>
+      </div>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-16">
+      <div className="container mx-auto px-4 max-w-xl">
+        <div className="animate-pulse space-y-4">
+          <div className="h-10 bg-gray-200 rounded w-3/4 mx-auto" />
+          <div className="h-4 bg-gray-200 rounded w-1/2 mx-auto" />
+          <div className="h-12 bg-gray-200 rounded mt-8" />
         </div>
       </div>
     </div>
   );
-} 
+}
+
+export default function InstallPage() {
+  return (
+    <Suspense fallback={<Skeleton />}>
+      <InstallContent />
+    </Suspense>
+  );
+}

--- a/src/components/RepoStatus.tsx
+++ b/src/components/RepoStatus.tsx
@@ -1,46 +1,162 @@
+'use client';
+
+import { useSessionHint } from '@/lib/session-context';
+import { useAuth } from '@/lib/auth/client';
+import { Github } from 'lucide-react';
+
 interface RepoStatusProps {
   error?: { message: string } | null;
+  owner?: string;
+  repo?: string;
 }
 
-export function RepoStatus({
-  error
-}: RepoStatusProps) {
-  if (error) {
-    const isNotFound = error.message.includes('not found') || error.message.includes('404');
-    const isUnauthorized = error.message.includes('unauthorized') || error.message.includes('401');
+const APP_NAME = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || 'gh-gg';
 
-    const title = isNotFound ? 'Repository Not Found'
-      : isUnauthorized ? 'Access Denied'
-      : 'Error Loading Repository';
+function buildInstallUrl(returnPath?: string) {
+  const base = `https://github.com/apps/${APP_NAME}/installations/new`;
+  return returnPath ? `${base}?state=${encodeURIComponent(returnPath)}` : base;
+}
 
-    const desc = isNotFound
-      ? 'The repository you\'re looking for doesn\'t exist or is private.'
-      : isUnauthorized
-      ? 'You don\'t have permission to access this repository.'
-      : error.message;
+export function RepoStatus({ error, owner, repo }: RepoStatusProps) {
+  const session = useSessionHint();
+  const { signIn } = useAuth();
+  const isSignedIn = !!session?.userId;
 
-    const color = isNotFound ? '#6b7280' : isUnauthorized ? '#f59e0b' : '#ea4335';
+  if (!error) return null;
 
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="w-[90%] max-w-[500px]">
-          <div className="bg-[#f8f9fa] py-[14px] px-[16px]" style={{ borderLeft: `3px solid ${color}` }}>
-            <div className="text-[13px] font-semibold uppercase tracking-[1px] mb-1" style={{ color }}>
-              {title}
-            </div>
-            <div className="text-base text-[#333] leading-[1.6]">
-              {desc}
-            </div>
-            {isNotFound && (
-              <div className="text-[13px] text-[#888] italic mt-2">
-                Try a public repository like: lantos1618/github.gg
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+  const msg = error.message || '';
+  const isRateLimit = msg.includes('rate limit') || msg.includes('429');
+  const isUnauthorized = !isRateLimit && (msg.includes('unauthorized') || msg.includes('401') || msg.includes('Bad credentials'));
+  const isNotFound = !isRateLimit && !isUnauthorized && (msg.includes('not found') || msg.includes('404'));
+
+  // Default to "likely private repo we can't see" framing on NOT_FOUND.
+  // Lead with install CTA. "Doesn't exist" is the fine-print fallback.
+  const isProbablyPrivate = isNotFound;
+
+  const returnPath = typeof window !== 'undefined' ? window.location.pathname + window.location.search : undefined;
+  const installUrl = buildInstallUrl(returnPath);
+
+  const repoLabel = owner && repo ? `${owner}/${repo}` : owner ? owner : 'this repository';
+
+  const accent = isRateLimit ? '#f59e0b' : isUnauthorized ? '#f59e0b' : isProbablyPrivate ? '#2563eb' : '#ea4335';
+
+  let title: string;
+  let body: React.ReactNode;
+  let primary: React.ReactNode = null;
+  let secondary: React.ReactNode = null;
+
+  if (isProbablyPrivate) {
+    title = "Can't see this repo";
+    body = (
+      <>
+        If <span className="font-mono">{repoLabel}</span> is private, github.gg needs the GitHub App installed on{' '}
+        <span className="font-mono">{owner || 'the owner'}</span> to fetch it.
+      </>
     );
+    primary = (
+      <a
+        href={installUrl}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[#111] hover:bg-[#333] rounded transition-colors"
+      >
+        <Github className="h-4 w-4" />
+        Install GitHub App{owner ? ` on ${owner}` : ''}
+      </a>
+    );
+    if (!isSignedIn) {
+      secondary = (
+        <button
+          onClick={() => signIn(returnPath)}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#111] bg-white border border-[#ddd] hover:bg-[#f5f5f5] rounded transition-colors"
+        >
+          Sign in with GitHub
+        </button>
+      );
+    }
+  } else if (isUnauthorized) {
+    title = 'Access denied';
+    body = (
+      <>
+        Your GitHub session isn&apos;t authorized for <span className="font-mono">{repoLabel}</span>. Try signing in again, or install the GitHub App on the owner.
+      </>
+    );
+    primary = (
+      <button
+        onClick={() => signIn(returnPath)}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[#111] hover:bg-[#333] rounded transition-colors"
+      >
+        <Github className="h-4 w-4" />
+        Sign in again
+      </button>
+    );
+    secondary = (
+      <a
+        href={installUrl}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#111] bg-white border border-[#ddd] hover:bg-[#f5f5f5] rounded transition-colors"
+      >
+        Install GitHub App
+      </a>
+    );
+  } else if (isRateLimit) {
+    title = 'GitHub rate limit hit';
+    body = (
+      <>
+        GitHub&apos;s API is temporarily throttled for this request. {isSignedIn ? 'Try again in a minute, or install the GitHub App for higher limits.' : 'Sign in for higher rate limits.'}
+      </>
+    );
+    primary = isSignedIn ? (
+      <a
+        href={installUrl}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[#111] hover:bg-[#333] rounded transition-colors"
+      >
+        Install GitHub App
+      </a>
+    ) : (
+      <button
+        onClick={() => signIn(returnPath)}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[#111] hover:bg-[#333] rounded transition-colors"
+      >
+        <Github className="h-4 w-4" />
+        Sign in with GitHub
+      </button>
+    );
+  } else {
+    title = 'Error loading repository';
+    body = <>{msg}</>;
   }
 
-  return null;
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <div className="w-[90%] max-w-[560px]">
+        <div className="bg-[#f8f9fa] py-[18px] px-[20px]" style={{ borderLeft: `3px solid ${accent}` }}>
+          <div className="text-[13px] font-semibold uppercase tracking-[1px] mb-1" style={{ color: accent }}>
+            {title}
+          </div>
+          <div className="text-base text-[#333] leading-[1.6] mb-4">{body}</div>
+
+          {(primary || secondary) && (
+            <div className="flex flex-wrap gap-2 mb-2">
+              {primary}
+              {secondary}
+            </div>
+          )}
+
+          {isProbablyPrivate && isSignedIn && (
+            <div className="text-[12px] text-[#666] mb-3">
+              On GitHub&apos;s next screen, pick <span className="font-semibold">Only select repositories</span> to grant access to just this one.
+            </div>
+          )}
+
+          {isProbablyPrivate && (
+            <div className="text-[12px] text-[#888] italic">
+              Or the repo may not exist. Try a public one like{' '}
+              <a href="/lantos1618/github.gg" className="underline hover:text-[#555]">
+                lantos1618/github.gg
+              </a>
+              .
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Private-repo onboarding was leaking new users. This PR reframes the flow end-to-end so users who hit a private repo can actually finish installing the GitHub App and land back where they started.

- **Error card** (`RepoStatus`) now defaults to **"Can't see this repo"** with a primary Install CTA (and a Sign-In CTA when signed out), instead of generic "Repository Not Found". Adds a one-line hint — *"pick Only select repositories on the next screen"* — right before the hand-off to GitHub (the highest-leverage conversion nudge I could find).
- **`/install` page** redesigned: scary OAuth scope pills are now behind a collapsible (progressive disclosure), value props lead the page, and we gate the install CTA behind sign-in to prevent orphan installations. "Connect GitHub Account" framing instead of "Install GitHub App".
- **`/install/callback`** honors a `state` query param and auto-redirects back to the repo the user originally came from, with a guard against external URLs. Install URL construction in `RepoStatus` sets `?state=<returnPath>` so GitHub's installation callback preserves it.
- **Layout fix** in `RepoClientView`: on error, render only the `RepoStatus` card instead of stacking it below the "No files selected" empty state.

## Test plan
- [x] Signed-out visit to `/lantos1618/some-private-repo-xyz` shows the new error card with Install + Sign-In CTAs (verified via Playwright)
- [x] Install URL carries `?state=%2Flantos1618%2Fsome-private-repo-xyz`
- [x] `/install` signed-out state shows sign-in gate
- [x] `/install/callback?setup_action=update&state=/lantos1618/github.gg` auto-redirects to `/lantos1618/github.gg`
- [x] External `state` URL (`https://evil.example.com/phish`) is rejected — stays on callback
- [ ] Signed-in no-install path on `/install` (requires real GitHub OAuth — untested, trusts existing `webhooks.getInstallationInfo` wiring)
- [ ] Full round-trip through GitHub's install screen on a preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)