### PR TITLE
fix: surface SSE errors and add scorecard generation timing

### DIFF
--- a/src/components/analysis/AnalysisPageView.tsx
+++ b/src/components/analysis/AnalysisPageView.tsx
@@ -209,11 +209,31 @@ function AnalysisPageViewInner<TResponse>({
   const createJobMutation = config.useCreateJob();
 
   // Step 2: Subscribe to SSE with just the jobId (tiny URL)
+  // Without onError, a failed SSE handshake (auth, server crash before first yield)
+  // leaves the UI stuck on the client's "Initializing..." state with no signal.
+  const handleSubscriptionError = useCallback((err: unknown) => {
+    const messageRaw = err instanceof Error ? err.message
+      : typeof err === 'string' ? err
+      : (err as { message?: string })?.message || 'Subscription failed before any data was received';
+    const message = sanitizeText(messageRaw);
+    if (isGitHubAuthError({ message })) {
+      setIsSubscriptionAuthError(true);
+    }
+    setError(message);
+    setShouldAnalyze(false);
+    setIsLoading(false);
+    setSseStatus('error');
+    setCurrentStep(message);
+    setLogs((prev) => [...prev, { message, timestamp: new Date(), type: 'error' }]);
+    console.error('[scorecard] SSE subscription error:', err);
+  }, []);
+
   config.useGenerateSubscription(
     { jobId: jobId || '' },
     {
       enabled: shouldAnalyze && !!jobId,
       onData: handleSubscriptionData,
+      onError: handleSubscriptionError,
     }
   );
 

--- a/src/lib/trpc/routes/scorecard.ts
+++ b/src/lib/trpc/routes/scorecard.ts
@@ -37,8 +37,17 @@ export const scorecardRouter = router({
       jobId: z.string(),
     }))
     .subscription(async function* ({ input, ctx }) {
-      // Retrieve job params from the store
+      const t0 = Date.now();
+      const tag = `[scorecard ${ctx.user.id} ${input.jobId.slice(0, 8)}]`;
+      const elapsed = () => `${Date.now() - t0}ms`;
+
+      // Yield connection-established event immediately so the client knows the
+      // SSE stream is live before any DB/Redis lookup happens. Otherwise a slow
+      // consumeJob/Redis call leaves the client stuck on its initial state.
+      yield { type: 'progress', progress: 0, message: 'Connected. Loading job...' };
+
       const job = await consumeJob(input.jobId, ctx.user.id);
+      console.log(`${tag} consumeJob ${elapsed()} found=${!!job}`);
       if (!job) {
         yield { type: 'error', message: 'Analysis job not found or expired. Please try again.' };
         return;
@@ -48,15 +57,16 @@ export const scorecardRouter = router({
       const repoNameNormalized = job.repo.toLowerCase();
 
       try {
-        yield { type: 'progress', progress: 0, message: 'Starting scorecard analysis...' };
+        yield { type: 'progress', progress: 1, message: 'Checking plan...' };
 
-        // Check subscription before doing any work
         const { subscription, plan } = await getUserPlanAndKey(ctx.user.id);
+        console.log(`${tag} getUserPlanAndKey ${elapsed()} plan=${plan} active=${subscription?.status}`);
         if (!subscription || subscription.status !== 'active') {
           yield { type: 'error', message: 'Active subscription required for AI features' };
           return;
         }
         const keyInfo = await getApiKeyForUser(ctx.user.id, plan);
+        console.log(`${tag} getApiKeyForUser ${elapsed()} hasKey=${!!keyInfo}`);
         if (!keyInfo) {
           yield { type: 'error', message: 'Please add your Gemini API key in settings to use this feature' };
           return;
@@ -65,9 +75,11 @@ export const scorecardRouter = router({
         yield { type: 'progress', progress: 3, message: 'Authenticating with GitHub...' };
 
         const githubService = await createGitHubServiceForRepo(job.user, job.repo, ctx.session);
+        console.log(`${tag} createGitHubServiceForRepo ${elapsed()}`);
 
         yield { type: 'progress', progress: 4, message: 'Fetching repository info...' };
         const repoInfo = await githubService.getRepositoryInfo(job.user, job.repo);
+        console.log(`${tag} getRepositoryInfo ${elapsed()} private=${repoInfo.private} defaultBranch=${repoInfo.defaultBranch}`);
         const ref = (!job.ref || job.ref === 'main') ? (repoInfo.defaultBranch || 'main') : job.ref;
         const isPrivate = repoInfo.private === true;
 


### PR DESCRIPTION
## Summary

User reports scorecard generation stuck at \"0% / Initializing analysis...\" with no error message — clicking Generate Analysis just spins forever. Root cause: \`useGenerateSubscription\` only had \`onData\`, so any unrecoverable subscription error (auth failure, server crash before first yield, network drop) was silently swallowed and the UI sat on its pre-server initial state.

## Changes

- **\`AnalysisPageView.tsx\`** — wire \`onError\` on the scorecard SSE subscription. Failures now land in the Live Logs panel as an error entry, the Regenerate button is restored, and \`isSubscriptionAuthError\` flags re-surface so the auth-error UI can take over for expired sessions.
- **\`scorecard.ts\`** — yield a \"Connected. Loading job...\" progress event as the very first generator action, before \`consumeJob\` runs. Otherwise a slow Redis call leaves the client with no SSE traffic and the same stuck-at-0% feel. Added per-step timing logs (\`[scorecard userId jobId] consumeJob 12ms ...\`) so we can diagnose which step hangs in prod.

## Test plan

- [ ] Trigger a scorecard generation on prod and confirm Live Logs show \"Connected. Loading job...\" before the first \"Starting...\" message
- [ ] Force a 401 (e.g., expire session) and confirm the SSE error surfaces in Live Logs instead of silent stuck
- [ ] Watch Vercel logs for \`[scorecard ...]\` lines on the next user-reported hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)