### PR TITLE
fix: '[object Object]' JSON crash + surface SSE errors in UI

### DIFF
--- a/src/components/analysis/AnalysisStateHandler.tsx
+++ b/src/components/analysis/AnalysisStateHandler.tsx
@@ -68,11 +68,22 @@ export const AnalysisStateHandler: React.FC<AnalysisStateHandlerProps> = ({
 
     case 'error':
       return (
-        <AnalysisErrorDisplay
-          error={error || 'An error occurred'}
-          isPending={isRegenerating}
-          onRetry={onRegenerate}
-        />
+        <div className="space-y-6">
+          <AnalysisErrorDisplay
+            error={error || 'An error occurred'}
+            isPending={isRegenerating}
+            onRetry={onRegenerate}
+          />
+          {sseLogs && sseLogs.length > 0 && (
+            <PageWidthContainer>
+              <ReusableSSEFeedback
+                status={sseStatus || 'error'}
+                progress={sseProgress || 0}
+                logs={sseLogs}
+              />
+            </PageWidthContainer>
+          )}
+        </div>
       );
 
     case 'no-data': {

--- a/src/components/ui/analysis-error-display.tsx
+++ b/src/components/ui/analysis-error-display.tsx
@@ -54,6 +54,12 @@ export function AnalysisErrorDisplay({
         <div className="bg-[#f8f9fa] py-[14px] px-[16px] text-left mb-6" style={{ borderLeft: `3px solid ${color}` }}>
           <div className="text-[13px] font-semibold uppercase tracking-[1px] mb-1" style={{ color }}>What happened</div>
           <div className="text-base text-[#333] leading-[1.6]">{config.explanation}</div>
+          {error && error !== config.explanation && (
+            <div className="mt-3 pt-3 border-t border-[#e5e5e5]">
+              <div className="text-[11px] font-semibold uppercase tracking-[1px] text-[#888] mb-1">Server message</div>
+              <div className="text-[13px] text-[#555] font-mono break-all whitespace-pre-wrap">{error}</div>
+            </div>
+          )}
         </div>
 
         {(onRetry || onRetryWithContext) && (

--- a/src/lib/analysis/job-store.ts
+++ b/src/lib/analysis/job-store.ts
@@ -53,28 +53,29 @@ if (isRedisConfigured) {
 // In-memory fallback for local dev (not production-safe)
 const memoryFallback = new Map<string, string>();
 
-async function redisSet(key: string, value: string, ttlSeconds: number): Promise<void> {
+// Store an object. We always JSON.stringify going in. Upstash will store the
+// string as-is; on read it auto-deserializes JSON-looking strings, so the
+// reader gets back the parsed object. We normalize that in redisGetJson.
+async function redisSetJson<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+  const str = JSON.stringify(value);
   if (redis) {
-    await redis.set(key, value, { ex: ttlSeconds });
+    await redis.set(key, str, { ex: ttlSeconds });
   } else {
-    memoryFallback.set(key, value);
+    memoryFallback.set(key, str);
     setTimeout(() => memoryFallback.delete(key), ttlSeconds * 1000);
   }
 }
 
-async function redisGet(key: string): Promise<string | null> {
+// Returns the stored object or null. Handles both Upstash auto-parsed
+// objects and the local memoryFallback (which stores raw strings).
+async function redisGetJson<T>(key: string): Promise<T | null> {
   if (redis) {
-    return await redis.get<string>(key);
+    const v = await redis.get<unknown>(key);
+    if (v === null || v === undefined) return null;
+    return (typeof v === 'string' ? JSON.parse(v) : v) as T;
   }
-  return memoryFallback.get(key) || null;
-}
-
-async function redisDel(key: string): Promise<void> {
-  if (redis) {
-    await redis.del(key);
-  } else {
-    memoryFallback.delete(key);
-  }
+  const raw = memoryFallback.get(key);
+  return raw ? (JSON.parse(raw) as T) : null;
 }
 
 // ─── Job Store (for POST+SSE two-step analysis) ────────────────────
@@ -88,7 +89,7 @@ const JOB_PREFIX = 'analysis:job:';
 export async function createJob(params: Omit<AnalysisJob, 'createdAt'>): Promise<string> {
   const jobId = crypto.randomBytes(16).toString('hex');
   const job: AnalysisJob = { ...params, createdAt: Date.now() };
-  await redisSet(`${JOB_PREFIX}${jobId}`, JSON.stringify(job), JOB_TTL);
+  await redisSetJson(`${JOB_PREFIX}${jobId}`, job, JOB_TTL);
   return jobId;
 }
 
@@ -102,12 +103,9 @@ export async function createJob(params: Omit<AnalysisJob, 'createdAt'>): Promise
  */
 export async function consumeJob(jobId: string, userId: string): Promise<AnalysisJob | null> {
   const key = `${JOB_PREFIX}${jobId}`;
-  const raw = await redisGet(key);
-  if (!raw) return null;
-
-  const job: AnalysisJob = JSON.parse(raw);
+  const job = await redisGetJson<AnalysisJob>(key);
+  if (!job) return null;
   if (job.userId !== userId) return null;
-
   return job;
 }
 
@@ -136,7 +134,7 @@ export async function enqueue(
   };
 
   // Store the item data
-  await redisSet(`${QUEUE_ITEM_PREFIX}${id}`, JSON.stringify(item), QUEUE_ITEM_TTL);
+  await redisSetJson(`${QUEUE_ITEM_PREFIX}${id}`, item, QUEUE_ITEM_TTL);
 
   // Push to the queue list (FIFO: push left, pop right)
   if (redis) {
@@ -156,13 +154,12 @@ export async function dequeue(type: QueueItem['type']): Promise<QueueItem | null
   const id = await redis.rpop<string>(`${QUEUE_PREFIX}${type}`);
   if (!id) return null;
 
-  const raw = await redisGet(`${QUEUE_ITEM_PREFIX}${id}`);
-  if (!raw) return null;
+  const item = await redisGetJson<QueueItem>(`${QUEUE_ITEM_PREFIX}${id}`);
+  if (!item) return null;
 
-  const item: QueueItem = JSON.parse(raw);
   item.status = 'processing';
   item.startedAt = Date.now();
-  await redisSet(`${QUEUE_ITEM_PREFIX}${id}`, JSON.stringify(item), QUEUE_ITEM_TTL);
+  await redisSetJson(`${QUEUE_ITEM_PREFIX}${id}`, item, QUEUE_ITEM_TTL);
 
   return item;
 }
@@ -174,21 +171,18 @@ export async function updateQueueItem(
   id: string,
   update: Partial<Pick<QueueItem, 'status' | 'error' | 'completedAt'>>,
 ): Promise<void> {
-  const raw = await redisGet(`${QUEUE_ITEM_PREFIX}${id}`);
-  if (!raw) return;
+  const item = await redisGetJson<QueueItem>(`${QUEUE_ITEM_PREFIX}${id}`);
+  if (!item) return;
 
-  const item: QueueItem = JSON.parse(raw);
   Object.assign(item, update);
-  await redisSet(`${QUEUE_ITEM_PREFIX}${id}`, JSON.stringify(item), QUEUE_ITEM_TTL);
+  await redisSetJson(`${QUEUE_ITEM_PREFIX}${id}`, item, QUEUE_ITEM_TTL);
 }
 
 /**
  * Get the status of a queue item.
  */
 export async function getQueueItem(id: string): Promise<QueueItem | null> {
-  const raw = await redisGet(`${QUEUE_ITEM_PREFIX}${id}`);
-  if (!raw) return null;
-  return JSON.parse(raw);
+  return await redisGetJson<QueueItem>(`${QUEUE_ITEM_PREFIX}${id}`);
 }
 
 /**
@@ -215,10 +209,9 @@ export async function getUserQueueItems(
   // Fetch items and filter by userId
   const items: QueueItem[] = [];
   for (const id of ids) {
-    const raw = await redisGet(`${QUEUE_ITEM_PREFIX}${id}`);
-    if (raw) {
-      const item: QueueItem = JSON.parse(raw);
-      if (item.userId === userId) items.push(item);
+    const item = await redisGetJson<QueueItem>(`${QUEUE_ITEM_PREFIX}${id}`);
+    if (item && item.userId === userId) {
+      items.push(item);
     }
   }
 


### PR DESCRIPTION
## Summary

User clicked Generate, got past the previous reconnect loop (PR #38 worked), but the very first SSE invocation crashed with:
\`\`\`
event: serialized-error
data: {\"message\":\"\\\"[object Object]\\\" is not valid JSON\",\"code\":-32603,\"data\":{\"code\":\"INTERNAL_SERVER_ERROR\",\"httpStatus\":500,\"path\":\"scorecard.generateScorecard\"}}
\`\`\`
…and they had to open the browser console to see it. The UI dropped the Live Logs panel as soon as the error fired.

## Bug 1 — Upstash auto-parse vs JSON.parse

\`consumeJob\` did \`JSON.parse(raw)\` where \`raw\` came from \`redis.get<string>(key)\`. Upstash's client transparently parses JSON-looking strings on read, so \`raw\` was already an \`AnalysisJob\` object. \`JSON.parse({...})\` coerces to \`\"[object Object]\"\` and throws. The pre-PR-#38 flow happened to mask this because the reconnect storm meant nobody ever made it past the parse cleanly — the idempotent consumeJob exposed the latent crash.

Fixed by replacing \`redisGet/redisSet\` with \`redisGetJson<T>/redisSetJson<T>\` helpers that:
- always JSON.stringify on write (consistent shape on the wire),
- handle both \`string\` (from local memoryFallback) and pre-parsed object (from Upstash) on read.

Same bug existed on the queue helpers (\`enqueue\`, \`dequeue\`, \`updateQueueItem\`, \`getQueueItem\`, \`getUserQueueItems\` — all used in admin routes), all routed through the new helpers. Dead \`redisDel\` removed.

## Bug 2 — error visibility

\`AnalysisStateHandler\` swapped to \`AnalysisErrorDisplay\` on error state, which dropped the Live Logs panel. \`AnalysisErrorDisplay\` itself only rendered a hardcoded \"Please try again or contact support\" line — the actual server message never made it to the UI.

- \`AnalysisErrorDisplay\` now shows the raw \`error\` string under \"What happened\" when it differs from the friendly explanation.
- \`AnalysisStateHandler\`'s 'error' state now renders the \`ReusableSSEFeedback\` panel below the error display when there are log entries, preserving the timeline.

## Test plan

- [ ] Click Generate; first call now succeeds past consumeJob (no more JSON parse crash)
- [ ] Force an error (e.g. disconnect Redis); confirm Live Logs stays visible AND the error message is in the \"What happened\" box without opening the console
- [ ] Admin queue endpoints still work (queue helpers route through same fixed primitives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)