### PR TITLE
fix: AI-slop wrong model name + cache resilience

### DIFF
--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -5,8 +5,10 @@ import { google } from '@ai-sdk/google';
  * Change the model name here to update all AI features at once.
  */
 export const GEMINI_PRO = google('models/gemini-3.1-pro-preview');
-export const GEMINI_FLASH = google('models/gemini-3.1-flash');
+// `gemini-3.1-flash` doesn't exist on v1beta. The 3.x flash family is
+// gemini-3-flash-preview (full) and gemini-3.1-flash-lite-preview (lite).
+export const GEMINI_FLASH = google('models/gemini-3-flash-preview');
 
 /** Model name strings for token usage logging */
 export const GEMINI_PRO_MODEL_NAME = 'gemini-3.1-pro-preview';
-export const GEMINI_FLASH_MODEL_NAME = 'gemini-3.1-flash';
+export const GEMINI_FLASH_MODEL_NAME = 'gemini-3-flash-preview';

--- a/src/lib/trpc/routes/ai-slop.ts
+++ b/src/lib/trpc/routes/ai-slop.ts
@@ -255,69 +255,76 @@ export const aiSlopRouter = router({
       }
     }),
 
-  // Unified public endpoint: fetch latest or specific version of an AI slop analysis
+  // Unified public endpoint: fetch latest or specific version of an AI slop analysis.
+  // Same resilience as publicGetScorecard: cached analyses are the source of truth,
+  // never block returning them on a live GitHub API call (which can flake).
   publicGetAISlop: publicProcedure
     .input(z.object({
       user: z.string(),
       repo: z.string(),
-      ref: z.string().optional().default('main'),
+      ref: z.string().optional(),
       version: z.number().optional(),
     }))
     .query(async ({ input, ctx }) => {
-      const { user, repo, ref, version } = input;
+      const { user, repo, version } = input;
       const normalizedUser = user.toLowerCase();
       const normalizedRepo = repo.toLowerCase();
 
-      // Check repository access and privacy
+      // Try to resolve ref + privacy from GitHub. Failures are soft —
+      // we can still serve the cached analysis if the repo info call hiccups.
+      let ref = input.ref;
+      let repoIsPrivate: boolean | null = null;
       try {
         const githubService = await createGitHubServiceForRepo(user, repo, ctx.session);
         const repoInfo = await githubService.getRepositoryInfo(user, repo);
+        repoIsPrivate = repoInfo.private === true;
+        if (!ref) ref = repoInfo.defaultBranch || 'main';
+      } catch (err) {
+        const message = (err as { message?: string })?.message;
+        console.warn(`[publicGetAISlop ${normalizedUser}/${normalizedRepo}] repo info fetch failed (will still try cache):`, message);
+      }
 
-        // If the repository is private, check if user has access
-        if (repoInfo.private === true) {
-          // If user is not authenticated, block access
-          if (!ctx.session?.user) {
-            return {
-              analysis: null,
-              cached: false,
-              stale: false,
-              lastUpdated: null,
-              error: 'This repository is private'
-            };
-          }
-
-          // User is authenticated, so they should have access (since we successfully fetched repo info)
-          // Continue to show the analysis
-        }
-      } catch {
-        // If we can't access the repo (404 or no auth), it might be private or user doesn't have access
+      if (repoIsPrivate === true && !ctx.session?.user) {
         return {
           analysis: null,
           cached: false,
           stale: false,
           lastUpdated: null,
-          error: 'Unable to access repository'
+          error: 'This repository is private',
         };
       }
 
-      // Use case-insensitive comparison for repoOwner/repoName
       const baseConditions = [
         sql`LOWER(${aiSlopAnalyses.repoOwner}) = ${normalizedUser}`,
         sql`LOWER(${aiSlopAnalyses.repoName}) = ${normalizedRepo}`,
-        eq(aiSlopAnalyses.ref, ref),
       ];
       if (version !== undefined) {
         baseConditions.push(eq(aiSlopAnalyses.version, version));
       }
-      const cached = await db
-        .select()
-        .from(aiSlopAnalyses)
-        .where(and(...baseConditions))
-        .orderBy(desc(aiSlopAnalyses.updatedAt))
-        .limit(1);
+
+      const refSpecific = ref
+        ? await db
+            .select()
+            .from(aiSlopAnalyses)
+            .where(and(...baseConditions, eq(aiSlopAnalyses.ref, ref)))
+            .orderBy(desc(aiSlopAnalyses.updatedAt))
+            .limit(1)
+        : [];
+
+      // Fall back to ANY ref if requested ref has no rows — guards historical
+      // main↔master mismatch in cached records.
+      const cached = refSpecific.length > 0
+        ? refSpecific
+        : await db
+            .select()
+            .from(aiSlopAnalyses)
+            .where(and(...baseConditions))
+            .orderBy(desc(aiSlopAnalyses.updatedAt))
+            .limit(1);
+
       if (cached.length > 0) {
         const analysis = cached[0];
-        const isStale = new Date().getTime() - analysis.updatedAt.getTime() > 24 * 60 * 60 * 1000; // 24 hours
+        const isStale = new Date().getTime() - analysis.updatedAt.getTime() > 24 * 60 * 60 * 1000;
         return {
           analysis: {
             metrics: analysis.metrics,

--- a/src/lib/utils/cost-calculator.ts
+++ b/src/lib/utils/cost-calculator.ts
@@ -46,7 +46,7 @@ export function calculateTokenCost(usage: TokenUsage): CostBreakdown {
   let outputCost = 0;
 
   // Determine pricing based on model
-  if (model.includes('gemini-3.1-flash') || model.includes('gemini-2.5-flash')) {
+  if (model.includes('gemini-3-flash') || model.includes('gemini-3.1-flash') || model.includes('gemini-2.5-flash')) {
     inputCost = (inputTokens / 1_000_000) * GEMINI_2_5_FLASH_PRICING.input;
     outputCost = (outputTokens / 1_000_000) * GEMINI_2_5_FLASH_PRICING.output;
   } else if (model.includes('gemini-3.1-pro') || model.includes('gemini-2.5-pro')) {


### PR DESCRIPTION
## Summary

User pushed AI-slop generation past all the SSE bugs from earlier PRs and hit:
\`\`\`
models/gemini-3.1-flash is not found for API version v1beta
\`\`\`
There is no \`gemini-3.1-flash\`. The 3.x flash family is \`gemini-3-flash-preview\` and \`gemini-3.1-flash-lite-preview\`. Switching to \`gemini-3-flash-preview\`.

Also applied the same cache resilience to \`publicGetAISlop\` that PR #37 applied to scorecard.

## Changes

- \`src/lib/ai/models.ts\` — \`GEMINI_FLASH\` now points at \`gemini-3-flash-preview\`; \`GEMINI_FLASH_MODEL_NAME\` updated to match for token logging.
- \`src/lib/utils/cost-calculator.ts\` — pricing match now recognizes \`gemini-3-flash\` in addition to existing patterns.
- \`src/lib/trpc/routes/ai-slop.ts\` \`publicGetAISlop\`:
  - \`getRepositoryInfo\` failure is soft (log + continue), cached analyses no longer blocked on live GitHub API.
  - \`ref\` defaults to resolved default branch instead of hardcoded 'main'.
  - Fallback to ANY ref if resolved ref has no rows (main↔master mismatch).
  - Privacy block only fires when actually verified private.

## Test plan

- [ ] Click Generate on \`/content-intelligence/ai-slop\` and confirm chunks complete (was failing on Gemini API call)
- [ ] Visit a repo with cached AI-slop on a different ref — should now serve the cache instead of "no analysis"
- [ ] Cost calculator shows correct flash pricing for new model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)