### PR TITLE
fix: use gemini-3.1-flash-lite-preview

### DIFF
--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -5,10 +5,10 @@ import { google } from '@ai-sdk/google';
  * Change the model name here to update all AI features at once.
  */
 export const GEMINI_PRO = google('models/gemini-3.1-pro-preview');
-// `gemini-3.1-flash` doesn't exist on v1beta. The 3.x flash family is
-// gemini-3-flash-preview (full) and gemini-3.1-flash-lite-preview (lite).
-export const GEMINI_FLASH = google('models/gemini-3-flash-preview');
+// `gemini-3.1-flash` (full) doesn't exist on v1beta — only the lite variant.
+// 3.x flash options: gemini-3-flash-preview (3.0) | gemini-3.1-flash-lite-preview (3.1).
+export const GEMINI_FLASH = google('models/gemini-3.1-flash-lite-preview');
 
 /** Model name strings for token usage logging */
 export const GEMINI_PRO_MODEL_NAME = 'gemini-3.1-pro-preview';
-export const GEMINI_FLASH_MODEL_NAME = 'gemini-3-flash-preview';
+export const GEMINI_FLASH_MODEL_NAME = 'gemini-3.1-flash-lite-preview';

--- a/src/lib/ai/wiki-generator.ts
+++ b/src/lib/ai/wiki-generator.ts
@@ -126,7 +126,7 @@ ${f.content}
   // Create cached content using Gemini API with retry logic
   const cacheResponse = await retryWithBackoff(() =>
     genAI.caches.create({
-      model: 'gemini-3-flash-preview',
+      model: 'gemini-3.1-flash-lite-preview',
       config: {
         systemInstruction: 'You are a documentation generator. This cached content contains a complete codebase for wiki generation.',
         contents: [{
@@ -185,7 +185,7 @@ Return ONLY valid JSON matching this structure:
 
   const result = await retryWithBackoff(() =>
     genAI.models.generateContent({
-      model: 'gemini-3-flash-preview',
+      model: 'gemini-3.1-flash-lite-preview',
       contents: prompt,
       config: {
         cachedContent: cacheId,
@@ -338,7 +338,7 @@ Start directly with the content.`;
 
   const result = await retryWithBackoff(() =>
     genAI.models.generateContent({
-      model: 'gemini-3-flash-preview',
+      model: 'gemini-3.1-flash-lite-preview',
       contents: prompt,
       config: {
         cachedContent: cacheId,

--- a/src/lib/trpc/routes/wiki.ts
+++ b/src/lib/trpc/routes/wiki.ts
@@ -142,7 +142,7 @@ export const wikiRouter = router({
             feature: 'wiki_generation',
             repoOwner: owner,
             repoName: repo,
-            model: 'gemini-3.1-flash',
+            model: 'gemini-3.1-flash-lite-preview',
             inputTokens: wikiResult.usage.inputTokens,
             outputTokens: wikiResult.usage.outputTokens,
             totalTokens: wikiResult.usage.totalTokens,


### PR DESCRIPTION
Switch to 3.1 family per user ask. `gemini-3.1-flash` (full) doesn't exist on v1beta — only the lite variant. Verified all required methods (`generateContent`, `createCachedContent`, etc.) supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)