### PR TITLE
feat(search): semantic embedding search across repo scorecards + similar projects rail

### DIFF
--- a/drizzle/0026_add_scorecard_embeddings.sql
+++ b/drizzle/0026_add_scorecard_embeddings.sql
@@ -1,0 +1,12 @@
+-- pgvector is already enabled by 0021_add_profile_embeddings.sql; included for
+-- idempotency if 0026 is the first migration run on a fresh DB after a squash.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Embedding column on repository_scorecards (Gemini text-embedding-004, 768 dims).
+ALTER TABLE repository_scorecards ADD COLUMN IF NOT EXISTS embedding vector(768);
+
+-- HNSW cosine index for fast approximate nearest neighbour search.
+-- drizzle-kit doesn't emit HNSW indexes for pgvector custom types, so this is
+-- hand-rolled (same as 0021_add_profile_embeddings.sql).
+CREATE INDEX IF NOT EXISTS idx_scorecard_embedding ON repository_scorecards
+USING hnsw (embedding vector_cosine_ops);

--- a/scripts/embed-scorecards.ts
+++ b/scripts/embed-scorecards.ts
@@ -1,0 +1,85 @@
+/**
+ * Backfill scorecard embeddings for rows where embedding IS NULL.
+ *
+ * After deploying migration 0026_add_scorecard_embeddings.sql, every NEW
+ * scorecard gets an embedding on write (see src/lib/trpc/routes/scorecard.ts).
+ * This script populates embeddings for the historical rows so semantic search
+ * and similar-repos start finding existing scorecards immediately.
+ *
+ * Run with:
+ *   bun --env-file=.env.local scripts/embed-scorecards.ts --dry-run
+ *   bun --env-file=.env.local scripts/embed-scorecards.ts
+ *   bun --env-file=.env.local scripts/embed-scorecards.ts --limit 50
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const limitArg = process.argv.indexOf('--limit');
+// Default cap of 500 protects against OOM on a fresh prod table with many rows
+// — re-run the script until it reports 0 to drain. Override with `--limit N`.
+const LIMIT = limitArg >= 0 ? Number(process.argv[limitArg + 1]) : 500;
+
+import { db } from '../src/db';
+import { repositoryScorecards } from '../src/db/schema';
+import { isNull, sql } from 'drizzle-orm';
+import { generateScorecardEmbedding } from '../src/lib/ai/embeddings';
+
+async function main() {
+  console.log(`[backfill] mode=${DRY_RUN ? 'DRY_RUN' : 'WRITE'} limit=${LIMIT}`);
+
+  const rows = await db
+    .select({
+      id: repositoryScorecards.id,
+      repoOwner: repositoryScorecards.repoOwner,
+      repoName: repositoryScorecards.repoName,
+      overallScore: repositoryScorecards.overallScore,
+      markdown: repositoryScorecards.markdown,
+    })
+    .from(repositoryScorecards)
+    .where(isNull(repositoryScorecards.embedding))
+    .limit(LIMIT);
+  console.log(`[backfill] ${rows.length} rows to embed (cap=${LIMIT})`);
+
+  let succeeded = 0;
+  let failed = 0;
+  let i = 0;
+
+  for (const row of rows) {
+    i++;
+    const tag = `${row.repoOwner}/${row.repoName}`;
+    try {
+      const embedding = await generateScorecardEmbedding({
+        repoOwner: row.repoOwner,
+        repoName: row.repoName,
+        overallScore: row.overallScore,
+        markdown: row.markdown,
+      });
+
+      if (!DRY_RUN) {
+        await db.execute(sql`
+          UPDATE repository_scorecards
+          SET embedding = ${'[' + embedding.join(',') + ']'}::vector
+          WHERE id = ${row.id}
+        `);
+      }
+
+      succeeded++;
+      if (i % 10 === 0 || i === rows.length) {
+        console.log(`[backfill] ${i}/${rows.length}  ✓ ${tag}`);
+      }
+    } catch (err) {
+      failed++;
+      console.error(`[backfill] ✗ ${tag}: ${err instanceof Error ? err.message : err}`);
+    }
+
+    // Gentle pacing — Gemini embeddings have a per-minute quota.
+    await new Promise(r => setTimeout(r, 50));
+  }
+
+  console.log(`[backfill] done. succeeded=${succeeded} failed=${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('[backfill] fatal:', err);
+  process.exit(1);
+});

--- a/src/components/analysis/AnalysisPageView.tsx
+++ b/src/components/analysis/AnalysisPageView.tsx
@@ -13,6 +13,7 @@ import { ReusableSSEFeedback, type SSELogItem, type SSEStatus } from '@/componen
 import { AnalysisHeader } from './AnalysisHeader';
 import { AnalysisResultRenderer } from './AnalysisResultRenderer';
 import { AnalysisStateHandler } from './AnalysisStateHandler';
+import { SimilarReposRail } from '@/components/repos/SimilarReposRail';
 
 import { trpc } from '@/lib/trpc/client';
 import { isGitHubAuthError } from '@/lib/hooks/useGitHubAuthError';
@@ -361,6 +362,10 @@ function AnalysisPageViewInner<TResponse>({
               data={{ markdown: markdownContent }}
               title={config.title}
             />
+          )}
+
+          {config.upgradeFeature === 'scorecard' && (analysisDataObj || markdownContent) && (
+            <SimilarReposRail owner={user} repo={repo} />
           )}
         </div>
 

--- a/src/components/repos/ReposClientView.tsx
+++ b/src/components/repos/ReposClientView.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Input } from '@/components/ui/input';
-import { Search, ArrowUpDown } from 'lucide-react';
+import { Search, ArrowUpDown, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
 import { ScorecardMetric } from '@/lib/types/scorecard';
 import { PageWidthContainer } from '@/components/PageWidthContainer';
+import { trpc } from '@/lib/trpc/client';
 
 type SortField = 'date' | 'score' | 'name';
 type SortOrder = 'asc' | 'desc';
@@ -19,6 +20,7 @@ interface RepositoryScorecardEntry {
   metrics: ScorecardMetric[];
   ref: string | null;
   version: number;
+  similarityScore?: number;
 }
 
 interface ReposClientViewProps {
@@ -26,16 +28,52 @@ interface ReposClientViewProps {
   totalRepoCount: number;
 }
 
+const SEMANTIC_MIN_CHARS = 2;
+const DEBOUNCE_MS = 250;
+
 export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientViewProps) {
   const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
   const [sortField, setSortField] = useState<SortField>('date');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [page, setPage] = useState(0);
   const pageSize = 20;
 
-  const filteredRepos = initialRepos?.filter(repo =>
-    `${repo.repoOwner}/${repo.repoName}`.toLowerCase().includes(searchQuery.toLowerCase())
-  ) || [];
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(searchQuery.trim()), DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [searchQuery]);
+
+  const semanticEnabled = debouncedQuery.length >= SEMANTIC_MIN_CHARS;
+  const { data: semantic, isFetching } = trpc.repoSearch.searchRepos.useQuery(
+    { query: debouncedQuery, limit: 100, offset: 0 },
+    {
+      enabled: semanticEnabled,
+      staleTime: 30_000,
+      placeholderData: (prev) => prev,
+    }
+  );
+
+  // When a semantic query is active, sort by relevance (similarity) instead of
+  // user-chosen sort — relevance is what they asked for. They can still
+  // re-sort by name/score/date after the fact via the column toggles.
+  const isSemanticMode = semanticEnabled;
+  const semanticHasResults = isSemanticMode && (semantic?.results.length ?? 0) > 0;
+
+  const sourceRepos: RepositoryScorecardEntry[] = useMemo(() => {
+    if (!isSemanticMode) return initialRepos ?? [];
+    if (!semantic) return [];
+    return semantic.results.map((r) => ({
+      repoOwner: r.repoOwner,
+      repoName: r.repoName,
+      overallScore: r.overallScore,
+      updatedAt: r.updatedAt,
+      metrics: [] as ScorecardMetric[],
+      ref: r.ref,
+      version: r.version,
+      similarityScore: r.similarityScore,
+    }));
+  }, [isSemanticMode, semantic, initialRepos]);
 
   const comparators: Record<SortField, (a: RepositoryScorecardEntry, b: RepositoryScorecardEntry) => number> = {
     date: (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
@@ -43,10 +81,20 @@ export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientVie
     name: (a, b) => `${a.repoOwner}/${a.repoName}`.localeCompare(`${b.repoOwner}/${b.repoName}`),
   };
 
-  const sortedRepos = [...filteredRepos].sort((a, b) => {
-    const comparison = comparators[sortField](a, b);
-    return sortOrder === 'asc' ? -comparison : comparison;
-  });
+  // In semantic mode the server already returns by similarity. Only re-sort if
+  // the user explicitly clicked a column header (which we detect by tracking
+  // whether sort defaults are active).
+  const sortedRepos = useMemo(() => {
+    if (isSemanticMode && sortField === 'date' && sortOrder === 'desc') {
+      // Trust server-side similarity ordering.
+      return sourceRepos;
+    }
+    return [...sourceRepos].sort((a, b) => {
+      const comparison = comparators[sortField](a, b);
+      return sortOrder === 'asc' ? -comparison : comparison;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sourceRepos, sortField, sortOrder, isSemanticMode]);
 
   const totalPages = Math.ceil(sortedRepos.length / pageSize);
   const paginatedRepos = sortedRepos.slice(page * pageSize, (page + 1) * pageSize);
@@ -57,6 +105,9 @@ export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientVie
     setPage(0);
   };
 
+  const showSemanticBadge = isSemanticMode && semanticHasResults;
+  const isSearching = isSemanticMode && isFetching && !semantic;
+
   return (
     <div className="min-h-screen bg-white pt-12 pb-20">
       <PageWidthContainer>
@@ -66,12 +117,17 @@ export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientVie
               Repositories
               <span className="text-base font-normal text-[#888] ml-3">{totalRepoCount.toLocaleString()}</span>
             </h1>
+            {showSemanticBadge && (
+              <p className="text-xs text-[#888] mt-2 inline-flex items-center gap-1.5">
+                <Sparkles className="h-3 w-3" /> Semantic match — ranked by similarity to your query
+              </p>
+            )}
           </div>
-          <div className="group relative w-64 flex-shrink-0">
+          <div className="group relative w-72 flex-shrink-0">
             <Search className="absolute left-0 top-1/2 -translate-y-1/2 h-4 w-4 text-[#ccc] group-focus-within:text-[#111] transition-colors" />
             <Input
               type="text"
-              placeholder="Search repositories..."
+              placeholder="Search by name or describe a project…"
               value={searchQuery}
               onChange={(e) => { setSearchQuery(e.target.value); setPage(0); }}
               className="pl-6"
@@ -79,9 +135,15 @@ export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientVie
           </div>
         </div>
 
-        {paginatedRepos.length === 0 ? (
+        {isSearching ? (
           <div className="py-16 text-center">
-            <p className="text-base text-[#aaa]">{searchQuery ? 'No repositories found.' : 'No analyzed repositories yet.'}</p>
+            <p className="text-base text-[#aaa]">Searching…</p>
+          </div>
+        ) : paginatedRepos.length === 0 ? (
+          <div className="py-16 text-center">
+            <p className="text-base text-[#aaa]">
+              {searchQuery ? 'No repositories found.' : 'No analyzed repositories yet.'}
+            </p>
           </div>
         ) : (
           <>
@@ -95,7 +157,7 @@ export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientVie
                     <span className="inline-flex items-center gap-1">Score <ArrowUpDown className={`h-3 w-3 ${sortField !== 'score' ? 'invisible' : ''}`} /></span>
                   </td>
                   <td className="w-[25%] py-2 text-xs text-[#999] font-semibold text-right cursor-pointer hover:text-[#111] transition-colors hidden sm:table-cell" onClick={() => toggleSort('date')}>
-                    <span className="inline-flex items-center gap-1">Analyzed <ArrowUpDown className={`h-3 w-3 ${sortField !== 'date' ? 'invisible' : ''}`} /></span>
+                    <span className="inline-flex items-center gap-1">{isSemanticMode ? 'Match' : 'Analyzed'} <ArrowUpDown className={`h-3 w-3 ${sortField !== 'date' ? 'invisible' : ''}`} /></span>
                   </td>
                 </tr>
               </thead>
@@ -123,7 +185,11 @@ export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientVie
                       </td>
                       <td className="py-3 text-right hidden sm:table-cell" suppressHydrationWarning>
                         <Link href={`/${fullName}/scorecard`} className="text-base text-[#888]">
-                          {formatDistanceToNow(new Date(repo.updatedAt), { addSuffix: true })}
+                          {isSemanticMode && repo.similarityScore !== undefined ? (
+                            <span className="font-mono text-[13px]">{Math.round(repo.similarityScore * 100)}%</span>
+                          ) : (
+                            formatDistanceToNow(new Date(repo.updatedAt), { addSuffix: true })
+                          )}
                         </Link>
                       </td>
                     </tr>

--- a/src/components/repos/SimilarReposRail.tsx
+++ b/src/components/repos/SimilarReposRail.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+import { Sparkles } from 'lucide-react';
+import { trpc } from '@/lib/trpc/client';
+
+interface SimilarReposRailProps {
+  owner: string;
+  repo: string;
+  limit?: number;
+}
+
+// Renders nothing when no embedding exists for the source repo or no
+// neighbours found — so it's safe to drop unconditionally into a scorecard
+// view, even for fresh / private / un-embedded repos.
+export function SimilarReposRail({ owner, repo, limit = 6 }: SimilarReposRailProps) {
+  const { data, isLoading } = trpc.repoSearch.getSimilarRepos.useQuery(
+    { owner, repo, limit },
+    { staleTime: 5 * 60_000 }
+  );
+
+  if (isLoading) return null;
+  if (!data || data.results.length === 0) return null;
+
+  return (
+    <section className="mt-10 pt-8 border-t border-[#eee]">
+      <div className="flex items-center gap-2 mb-4">
+        <Sparkles className="h-4 w-4 text-[#888]" />
+        <h2 className="text-base font-semibold text-[#111]">Similar projects</h2>
+        <span className="text-xs text-[#aaa]">ranked by semantic similarity</span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {data.results.map((r) => {
+          const fullName = `${r.repoOwner}/${r.repoName}`;
+          return (
+            <Link
+              key={`${fullName}-${r.version}`}
+              href={`/${fullName}/scorecard`}
+              className="block p-3 border border-[#eee] rounded-md hover:border-[#111] transition-colors group"
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-medium text-[#111] truncate group-hover:text-[#666] transition-colors">
+                  {fullName}
+                </span>
+                <span className="text-xs font-mono text-[#888] flex-shrink-0">
+                  {Math.round(r.similarityScore * 100)}%
+                </span>
+              </div>
+              <div className="text-xs text-[#888] mt-1">
+                Score <span className="font-semibold text-[#111]">{r.overallScore}</span>
+                <span className="text-[#ccc]">/100</span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/db/schema/repository.ts
+++ b/src/db/schema/repository.ts
@@ -91,6 +91,7 @@ export const repositoryScorecards = pgTable('repository_scorecards', {
   overallScore: integer('overall_score').notNull(), // 0-100 overall score
   metrics: jsonb('metrics').$type<ScorecardMetric[]>().notNull(), // Structured metrics breakdown
   markdown: text('markdown').notNull(), // Full markdown analysis
+  embedding: vector('embedding', { dimensions: 768 }), // Gemini text-embedding-004, populated on write
   fileHashes: jsonb('file_hashes').$type<Record<string, string>>(), // Hash of files to detect changes
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/src/lib/ai/embeddings.ts
+++ b/src/lib/ai/embeddings.ts
@@ -98,6 +98,36 @@ export async function generateJobEmbedding(jobDescription: string): Promise<numb
   return generateEmbedding(prefixedText);
 }
 
+// text-embedding-004 has a token budget around ~2k. Markdown scorecards routinely
+// run longer than that, so trim before embedding. Character cap is conservative
+// (~1 token per 4 chars in English prose, less in code blocks).
+const SCORECARD_EMBED_CHAR_LIMIT = 6000;
+
+interface ScorecardEmbeddingInput {
+  repoOwner: string;
+  repoName: string;
+  overallScore: number;
+  markdown: string;
+}
+
+/**
+ * Build the text we embed for a repository scorecard. Front-loads the repo
+ * identifier so a query like "github.gg" still surfaces this repo even if
+ * the markdown body never mentions the name.
+ */
+export function scorecardToEmbeddingText(input: ScorecardEmbeddingInput): string {
+  const head = `Repository: ${input.repoOwner}/${input.repoName}\nOverall Score: ${input.overallScore}/100`;
+  const body = input.markdown.slice(0, SCORECARD_EMBED_CHAR_LIMIT);
+  return `${head}\n\n${body}`;
+}
+
+/**
+ * Generate embedding for a repository scorecard.
+ */
+export async function generateScorecardEmbedding(input: ScorecardEmbeddingInput): Promise<number[]> {
+  return generateEmbedding(scorecardToEmbeddingText(input));
+}
+
 /**
  * Calculate cosine similarity between two embeddings
  * Returns a value between -1 and 1, where 1 is most similar

--- a/src/lib/trpc/routes.ts
+++ b/src/lib/trpc/routes.ts
@@ -17,6 +17,7 @@ import { wikiRouter } from '@/lib/trpc/routes/wiki';
 import { apiKeysRouter } from '@/lib/trpc/routes/api-keys';
 import { hireRouter } from '@/lib/trpc/routes/hire';
 import { discoverRouter } from '@/lib/trpc/routes/discover';
+import { repoSearchRouter } from '@/lib/trpc/routes/repo-search';
 import { z } from 'zod';
 import { router } from '@/lib/trpc/trpc';
 import { db } from '@/db';
@@ -142,6 +143,9 @@ export const appRouter = router({
 
   // Discover / network exploration
   discover: discoverRouter,
+
+  // Semantic repo search + similar-repos
+  repoSearch: repoSearchRouter,
 });
 
 export type AppRouter = typeof appRouter; 

--- a/src/lib/trpc/routes/repo-search.ts
+++ b/src/lib/trpc/routes/repo-search.ts
@@ -1,0 +1,269 @@
+import { z } from 'zod';
+import { router, publicProcedure } from '@/lib/trpc/trpc';
+import { db } from '@/db';
+import { sql } from 'drizzle-orm';
+import { generateEmbedding, formatEmbeddingForPg } from '@/lib/ai/embeddings';
+
+interface ScorecardSearchRow {
+  repoOwner: string;
+  repoName: string;
+  ref: string | null;
+  overallScore: number;
+  version: number;
+  updatedAt: Date;
+  similarityScore?: number;
+}
+
+export const repoSearchRouter = router({
+  // Semantic search over public scorecards. When `query` is a free-text string
+  // we embed it and rank by cosine similarity to the scorecard embedding.
+  // When `query` is empty (or shorter than 2 chars), we just return the
+  // newest public scorecards — so this procedure can back both the "browse"
+  // and "search" states of the repos page.
+  searchRepos: publicProcedure
+    .input(z.object({
+      query: z.string().optional(),
+      limit: z.number().min(1).max(100).optional().default(50),
+      offset: z.number().min(0).optional().default(0),
+    }))
+    .query(async ({ input, ctx }) => {
+      const { query, limit, offset } = input;
+      const trimmed = query?.trim() ?? '';
+
+      // Privacy: only public scorecards are searchable for everyone. Signed-in
+      // users additionally see their own private ones (matches getAllAnalyzedRepos).
+      const currentUserId = ctx.session?.user?.id;
+      const visibilityClause = currentUserId
+        ? sql`(s.is_private = false OR s.user_id = ${currentUserId})`
+        : sql`s.is_private = false`;
+
+      // Latest version per (repo_owner, repo_name, ref). We collapse on
+      // (owner, name) since the UI shows one row per repo; ties broken by
+      // most-recent updatedAt.
+      const latestPartition = sql`
+        SELECT *
+        FROM (
+          SELECT
+            s.*,
+            ROW_NUMBER() OVER (
+              PARTITION BY LOWER(s.repo_owner), LOWER(s.repo_name)
+              ORDER BY s.updated_at DESC, s.version DESC
+            ) AS rn
+          FROM repository_scorecards s
+          WHERE ${visibilityClause}
+        ) t
+        WHERE t.rn = 1
+      `;
+
+      if (trimmed.length >= 2) {
+        // Semantic path: embed the query, rank by cosine distance. We over-
+        // fetch (limit * 4) so a future filter step has room; for now we
+        // just slice.
+        let rows: ScorecardSearchRow[] = [];
+        try {
+          const queryEmbedding = await generateEmbedding(`Repository search: ${trimmed}`);
+          const embeddingStr = formatEmbeddingForPg(queryEmbedding);
+          const fetchLimit = Math.min(200, (limit + offset) * 4);
+          const vectorResults = await db.execute(sql`
+            WITH latest AS (${latestPartition})
+            SELECT
+              l.repo_owner as "repoOwner",
+              l.repo_name as "repoName",
+              l.ref as "ref",
+              l.overall_score as "overallScore",
+              l.version as "version",
+              l.updated_at as "updatedAt",
+              1 - (l.embedding <=> ${embeddingStr}::vector) as similarity_score
+            FROM latest l
+            WHERE l.embedding IS NOT NULL
+            ORDER BY l.embedding <=> ${embeddingStr}::vector
+            LIMIT ${fetchLimit}
+          `);
+          rows = (vectorResults as unknown as Array<{
+            repoOwner: string;
+            repoName: string;
+            ref: string | null;
+            overallScore: number;
+            version: number;
+            updatedAt: Date;
+            similarity_score: number;
+          }>).map(r => ({
+            repoOwner: r.repoOwner,
+            repoName: r.repoName,
+            ref: r.ref,
+            overallScore: r.overallScore,
+            version: r.version,
+            updatedAt: new Date(r.updatedAt),
+            similarityScore: Number(r.similarity_score) || 0,
+          }));
+        } catch (err) {
+          console.warn('[repoSearch.searchRepos] vector search failed, falling back to ILIKE:', err);
+        }
+
+        // Fallback / supplement: a plain substring match. We always run this
+        // when vector returned nothing, and merge it underneath vector hits
+        // when vector returned something — so repos without embeddings yet
+        // still show up if their name matches.
+        if (rows.length < limit + offset) {
+          // Escape LIKE metacharacters in user input so a query like "re_o" or
+          // "%" matches literally instead of being treated as a wildcard.
+          const escapedQuery = trimmed.toLowerCase().replace(/[\\%_]/g, '\\$&');
+          const ilikeResults = await db.execute(sql`
+            WITH latest AS (${latestPartition})
+            SELECT
+              l.repo_owner as "repoOwner",
+              l.repo_name as "repoName",
+              l.ref as "ref",
+              l.overall_score as "overallScore",
+              l.version as "version",
+              l.updated_at as "updatedAt"
+            FROM latest l
+            WHERE LOWER(l.repo_owner || '/' || l.repo_name) LIKE ${'%' + escapedQuery + '%'} ESCAPE '\\'
+            ORDER BY l.updated_at DESC
+            LIMIT ${limit + offset}
+          `);
+          const ilikeRows = (ilikeResults as unknown as ScorecardSearchRow[]).map(r => ({
+            ...r,
+            updatedAt: new Date(r.updatedAt),
+          }));
+          const seen = new Set(rows.map(r => `${r.repoOwner.toLowerCase()}/${r.repoName.toLowerCase()}`));
+          for (const r of ilikeRows) {
+            const key = `${r.repoOwner.toLowerCase()}/${r.repoName.toLowerCase()}`;
+            if (!seen.has(key)) {
+              rows.push(r);
+              seen.add(key);
+            }
+          }
+        }
+
+        // Semantic mode over-fetches up to fetchLimit; total/hasMore reflect
+        // what we have in hand, not a global COUNT (that would require a
+        // second pass). Good enough for UI hint, not authoritative.
+        return {
+          results: rows.slice(offset, offset + limit),
+          total: rows.length,
+          hasMore: rows.length > offset + limit,
+          mode: 'semantic' as const,
+          totalIsExact: false,
+        };
+      }
+
+      // Browse path: no query, just return newest first.
+      const browseResults = await db.execute(sql`
+        WITH latest AS (${latestPartition})
+        SELECT
+          l.repo_owner as "repoOwner",
+          l.repo_name as "repoName",
+          l.ref as "ref",
+          l.overall_score as "overallScore",
+          l.version as "version",
+          l.updated_at as "updatedAt"
+        FROM latest l
+        ORDER BY l.updated_at DESC
+        LIMIT ${limit} OFFSET ${offset}
+      `);
+      const rows = (browseResults as unknown as ScorecardSearchRow[]).map(r => ({
+        ...r,
+        updatedAt: new Date(r.updatedAt),
+      }));
+      return {
+        results: rows,
+        total: rows.length,
+        hasMore: rows.length === limit,
+        mode: 'browse' as const,
+      };
+    }),
+
+  // Given an (owner, repo), return the most semantically similar other repos
+  // based on the scorecard embedding. Mirrors discover.getSimilarDevelopers.
+  getSimilarRepos: publicProcedure
+    .input(z.object({
+      owner: z.string().min(1),
+      repo: z.string().min(1),
+      limit: z.number().min(1).max(20).optional().default(6),
+    }))
+    .query(async ({ input, ctx }) => {
+      const { owner, repo, limit } = input;
+      const currentUserId = ctx.session?.user?.id;
+      const visibilityClause = currentUserId
+        ? sql`(s.is_private = false OR s.user_id = ${currentUserId})`
+        : sql`s.is_private = false`;
+
+      // Source row: the latest embedded scorecard for the given (owner, repo).
+      // Apply the same visibility gate as the neighbours query — otherwise an
+      // unauthenticated caller can probe whether a private scorecard exists
+      // by observing whether this endpoint returns results vs 'unavailable'.
+      const sourceResult = await db.execute(sql`
+        SELECT embedding
+        FROM repository_scorecards
+        WHERE LOWER(repo_owner) = LOWER(${owner})
+          AND LOWER(repo_name) = LOWER(${repo})
+          AND embedding IS NOT NULL
+          AND ${currentUserId
+            ? sql`(is_private = false OR user_id = ${currentUserId})`
+            : sql`is_private = false`}
+        ORDER BY updated_at DESC, version DESC
+        LIMIT 1
+      `);
+      const source = sourceResult[0] as { embedding: string | null } | undefined;
+      if (!source?.embedding) {
+        return { results: [], mode: 'unavailable' as const };
+      }
+
+      // The pgvector driver returns the embedding as the literal pg-text form
+      // (e.g. "[0.01,0.02,...]"). It's already a valid ::vector cast input.
+      const embeddingStr = typeof source.embedding === 'string'
+        ? source.embedding
+        : formatEmbeddingForPg(source.embedding as number[]);
+
+      const neighbours = await db.execute(sql`
+        WITH latest AS (
+          SELECT *
+          FROM (
+            SELECT
+              s.*,
+              ROW_NUMBER() OVER (
+                PARTITION BY LOWER(s.repo_owner), LOWER(s.repo_name)
+                ORDER BY s.updated_at DESC, s.version DESC
+              ) AS rn
+            FROM repository_scorecards s
+            WHERE ${visibilityClause}
+              AND NOT (LOWER(s.repo_owner) = LOWER(${owner}) AND LOWER(s.repo_name) = LOWER(${repo}))
+          ) t
+          WHERE t.rn = 1
+        )
+        SELECT
+          l.repo_owner as "repoOwner",
+          l.repo_name as "repoName",
+          l.ref as "ref",
+          l.overall_score as "overallScore",
+          l.version as "version",
+          l.updated_at as "updatedAt",
+          1 - (l.embedding <=> ${embeddingStr}::vector) as similarity_score
+        FROM latest l
+        WHERE l.embedding IS NOT NULL
+        ORDER BY l.embedding <=> ${embeddingStr}::vector
+        LIMIT ${limit}
+      `);
+
+      const rows = (neighbours as unknown as Array<{
+        repoOwner: string;
+        repoName: string;
+        ref: string | null;
+        overallScore: number;
+        version: number;
+        updatedAt: Date;
+        similarity_score: number;
+      }>).map(r => ({
+        repoOwner: r.repoOwner,
+        repoName: r.repoName,
+        ref: r.ref,
+        overallScore: r.overallScore,
+        version: r.version,
+        updatedAt: new Date(r.updatedAt),
+        similarityScore: Number(r.similarity_score) || 0,
+      }));
+
+      return { results: rows, mode: 'semantic' as const };
+    }),
+});

--- a/src/lib/trpc/routes/scorecard.ts
+++ b/src/lib/trpc/routes/scorecard.ts
@@ -10,6 +10,7 @@ import { createGitHubServiceForRepo } from '@/lib/github';
 import { executeAnalysisWithVersioning } from '@/lib/trpc/helpers/analysis-executor';
 import { getUserPlanAndKey, getApiKeyForUser } from '@/lib/utils/user-plan';
 import { createJob, consumeJob } from '@/lib/analysis/job-store';
+import { generateScorecardEmbedding } from '@/lib/ai/embeddings';
 
 export const scorecardRouter = router({
   // Step 1: POST mutation to store file selection, returns a short jobId
@@ -278,6 +279,37 @@ export const scorecardRouter = router({
             updatedAt: new Date(),
           }),
         });
+
+        // Best-effort: compute + persist embedding for semantic search. Failures
+        // here must not break the analysis subscription — embedding is searchable
+        // by definition, not load-bearing for the scorecard view itself.
+        void (async () => {
+          try {
+            const embedding = await generateScorecardEmbedding({
+              repoOwner: repoOwnerNormalized,
+              repoName: repoNameNormalized,
+              overallScore: parsedData.overallScore,
+              markdown: parsedData.markdown,
+            });
+            await db
+              .update(repositoryScorecards)
+              .set({ embedding })
+              .where(
+                and(
+                  eq(repositoryScorecards.userId, ctx.user.id),
+                  eq(repositoryScorecards.repoOwner, repoOwnerNormalized),
+                  eq(repositoryScorecards.repoName, repoNameNormalized),
+                  eq(repositoryScorecards.ref, ref),
+                  eq(repositoryScorecards.version, (insertedRecord as { version: number }).version)
+                )
+              );
+          } catch (err) {
+            console.warn(
+              `[scorecard.embedding] failed for ${repoOwnerNormalized}/${repoNameNormalized}@${ref}:`,
+              err instanceof Error ? err.message : err
+            );
+          }
+        })();
 
         yield { type: 'progress', progress: 80, message: 'Analysis complete, saving results...' };
 


### PR DESCRIPTION
## Summary

Substring matching on `/repos` misses intent: searching "auth library" should find passport / NextAuth / supabase-auth, not nothing. This PR adds **semantic embedding search** over every analyzed repo, reusing the existing Gemini `text-embedding-004` + pgvector stack already powering profile/hire/discover.

Same embedding column also unlocks a **"Similar projects"** rail on every scorecard page.

## What ships

**Storage & generation**
- Migration `0026_add_scorecard_embeddings.sql` — `vector(768)` column + HNSW cosine index on `repository_scorecards` (hand-rolled like 0021; drizzle-kit doesn't emit HNSW)
- `scorecardToEmbeddingText` + `generateScorecardEmbedding` helpers in `src/lib/ai/embeddings.ts`
- Scorecard write path now fires a best-effort embedding UPDATE after each new version; failures log and never break analysis (`src/lib/trpc/routes/scorecard.ts`)
- `scripts/embed-scorecards.ts` backfills historical NULL embeddings (capped at 500 per run, re-run to drain)

**Search**
- New `repoSearch` tRPC router:
  - `searchRepos({ query, limit, offset })` — semantic ranking when `query.length >= 2`, supplemented with escaped ILIKE fallback so un-embedded rows still surface by name. Browse mode (empty query) returns newest. Public-only for anon, public + own private for signed-in.
  - `getSimilarRepos({ owner, repo, limit })` — cosine neighbours of a given repo. Source-row fetch is visibility-gated too, so we don't confirm existence of a private scorecard to a stranger.

**UI**
- `ReposClientView`: 250ms debounce, switches to semantic mode at 2+ chars, similarity % shown in the right column, "Match" replaces "Analyzed" header.
- `SimilarReposRail`: dropped into the scorecard view (gated on `config.upgradeFeature === 'scorecard'`); hides itself when there are no neighbours so it's a no-op for fresh/un-embedded repos.

## Test plan

- [ ] Run migration 0026 on dev DB (`bun --env-file=.env.local drizzle-kit migrate` or `db:push`)
- [ ] Generate a fresh scorecard, confirm the row gets an embedding (`SELECT embedding IS NOT NULL FROM repository_scorecards ORDER BY updated_at DESC LIMIT 1;`)
- [ ] Run `bun --env-file=.env.local scripts/embed-scorecards.ts --dry-run` then without `--dry-run` to backfill existing rows
- [ ] On `/repos`, type a free-text query ("auth library", "rust web framework") and confirm semantically-related repos appear with `%` match score
- [ ] On `/repos`, type a repo name fragment and confirm name matches still work (ILIKE fallback)
- [ ] Visit a scorecard page and confirm the "Similar projects" rail renders (or is silent if there are <1 neighbours)
- [ ] Signed-out user calling `/api/trpc/repoSearch.getSimilarRepos?input=...` for a known private repo gets `mode: 'unavailable'` (no leak)
- [ ] Type `%` or `_` into the search box — should not blow up, should not match-everything

## Notes

- Reviewer flagged 4 real issues in pre-merge review; all fixed before commit:
  - LIKE wildcard injection (`%`/`_`) — now escaped + `ESCAPE '\\'`
  - Privacy leak in `getSimilarRepos` source-row fetch — now visibility-gated
  - Backfill OOM risk — bounded `LIMIT 500` per run
  - Pagination correctness in semantic mode — clarified `totalIsExact: false` in payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)