### PR TITLE
fix(ui): theme similar-projects rail + semantic-match hint to match site

### DIFF
--- a/src/components/repos/ReposClientView.tsx
+++ b/src/components/repos/ReposClientView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { Input } from '@/components/ui/input';
-import { Search, ArrowUpDown, Sparkles } from 'lucide-react';
+import { Search, ArrowUpDown } from 'lucide-react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
 import { ScorecardMetric } from '@/lib/types/scorecard';
@@ -118,9 +118,9 @@ export function ReposClientView({ initialRepos, totalRepoCount }: ReposClientVie
               <span className="text-base font-normal text-[#888] ml-3">{totalRepoCount.toLocaleString()}</span>
             </h1>
             {showSemanticBadge && (
-              <p className="text-xs text-[#888] mt-2 inline-flex items-center gap-1.5">
-                <Sparkles className="h-3 w-3" /> Semantic match — ranked by similarity to your query
-              </p>
+              <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mt-2">
+                Semantic Match
+              </div>
             )}
           </div>
           <div className="group relative w-72 flex-shrink-0">

--- a/src/components/repos/SimilarReposRail.tsx
+++ b/src/components/repos/SimilarReposRail.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { Sparkles } from 'lucide-react';
 import { trpc } from '@/lib/trpc/client';
 
 interface SimilarReposRailProps {
@@ -23,37 +22,45 @@ export function SimilarReposRail({ owner, repo, limit = 6 }: SimilarReposRailPro
   if (!data || data.results.length === 0) return null;
 
   return (
-    <section className="mt-10 pt-8 border-t border-[#eee]">
-      <div className="flex items-center gap-2 mb-4">
-        <Sparkles className="h-4 w-4 text-[#888]" />
-        <h2 className="text-base font-semibold text-[#111]">Similar projects</h2>
-        <span className="text-xs text-[#aaa]">ranked by semantic similarity</span>
+    <section className="mt-10">
+      <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-2">
+        Similar Projects
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {data.results.map((r) => {
-          const fullName = `${r.repoOwner}/${r.repoName}`;
-          return (
-            <Link
-              key={`${fullName}-${r.version}`}
-              href={`/${fullName}/scorecard`}
-              className="block p-3 border border-[#eee] rounded-md hover:border-[#111] transition-colors group"
-            >
-              <div className="flex items-baseline justify-between gap-2">
-                <span className="font-medium text-[#111] truncate group-hover:text-[#666] transition-colors">
-                  {fullName}
-                </span>
-                <span className="text-xs font-mono text-[#888] flex-shrink-0">
-                  {Math.round(r.similarityScore * 100)}%
-                </span>
-              </div>
-              <div className="text-xs text-[#888] mt-1">
-                Score <span className="font-semibold text-[#111]">{r.overallScore}</span>
-                <span className="text-[#ccc]">/100</span>
-              </div>
-            </Link>
-          );
-        })}
-      </div>
+      <div className="border-b border-[#eee] mb-4" />
+      <table className="w-full text-base border-collapse table-fixed">
+        <tbody>
+          {data.results.map((r) => {
+            const fullName = `${r.repoOwner}/${r.repoName}`;
+            return (
+              <tr
+                key={`${fullName}-${r.version}`}
+                className="border-b border-[#f0f0f0] hover:bg-[#fafafa] transition-colors"
+              >
+                <td className="py-3 w-[60%]">
+                  <Link href={`/${fullName}/scorecard`} className="group block truncate">
+                    <span className="font-medium text-[#111] group-hover:text-[#666] transition-colors">
+                      {fullName}
+                    </span>
+                  </Link>
+                </td>
+                <td className="py-3 text-center hidden lg:table-cell w-[15%]">
+                  <Link href={`/${fullName}/scorecard`}>
+                    <span className="font-semibold text-[#111]">
+                      {r.overallScore}
+                      <span className="text-[13px] text-[#aaa] ml-0.5">/100</span>
+                    </span>
+                  </Link>
+                </td>
+                <td className="py-3 text-right w-[25%]">
+                  <Link href={`/${fullName}/scorecard`} className="text-base text-[#888] font-mono text-[13px]">
+                    {Math.round(r.similarityScore * 100)}%
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

The card grid + Sparkles icon in the new \`SimilarReposRail\` looked generic-SaaS next to the rest of the scorecard view, which is all minimal black-on-white tables with the uppercase-tracked section labels. Same for the \"Semantic Match\" hint I added on \`/repos\`.

- \`SimilarReposRail\`: card grid → same table layout used in \`/repos\` (Repository | Score | Match%), standard \`text-xs text-[#999] font-semibold tracking-[1.5px] uppercase\` section label. No icons.
- \`ReposClientView\`: \"Semantic Match\" hint gets the same treatment, Sparkles import dropped.

## Test plan

- [ ] Visit a scorecard for a repo with neighbours → rail uses the table layout, no card grid
- [ ] On \`/repos\` type 2+ chars → uppercase \"SEMANTIC MATCH\" label appears under the heading, no icon
- [ ] Empty results → rail still hides itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)