### PR TITLE
fix(ui): theme the hire pages to match site (no Sparkles, no amber/blue, no Card primitives)

### DIFF
--- a/src/app/hire/[username]/HiringReportClient.tsx
+++ b/src/app/hire/[username]/HiringReportClient.tsx
@@ -4,6 +4,7 @@ import { trpc } from '@/lib/trpc/client';
 import { Button } from '@/components/ui/button';
 import { SkillAssessment } from '@/components/profile/SkillAssessment';
 import { TopRepos } from '@/components/profile/TopRepos';
+import { PageWidthContainer } from '@/components/PageWidthContainer';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -11,20 +12,10 @@ import { toast } from 'sonner';
 import { useAuth } from '@/lib/auth/client';
 import { safePostHog } from '@/lib/analytics/posthog';
 import {
-  AlertTriangle,
-  CheckCircle,
-  XCircle,
   ArrowLeft,
   ExternalLink,
-  Loader2,
-  AlertCircle,
-  MessageSquare,
-  Shield,
-  User,
-  GitBranch,
   Bookmark,
   BookmarkCheck,
-  Users,
 } from 'lucide-react';
 
 const SHORTLIST_KEY = 'gg.hire.shortlist';
@@ -53,35 +44,16 @@ function saveToShortlist(username: string): boolean {
 
 type HiringReportClientProps = {
   username: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   initialData?: any;
 };
 
-function getRiskLevel(confidence: number | undefined, aiPercentage?: number): {
-  level: 'low' | 'medium' | 'high';
-  color: string;
-  bgColor: string;
-  label: string;
-} {
-  // If no data, medium risk by default
-  if (confidence === undefined) {
-    return { level: 'medium', color: 'text-amber-600', bgColor: 'bg-amber-50', label: 'Unknown' };
-  }
-
-  // High AI percentage is a red flag
-  if (aiPercentage && aiPercentage > 60) {
-    return { level: 'high', color: 'text-red-600', bgColor: 'bg-red-50', label: 'High Risk' };
-  }
-
-  // Low confidence is a red flag
-  if (confidence < 40) {
-    return { level: 'high', color: 'text-red-600', bgColor: 'bg-red-50', label: 'High Risk' };
-  }
-
-  if (confidence < 70 || (aiPercentage && aiPercentage > 40)) {
-    return { level: 'medium', color: 'text-amber-600', bgColor: 'bg-amber-50', label: 'Medium Risk' };
-  }
-
-  return { level: 'low', color: 'text-emerald-600', bgColor: 'bg-emerald-50', label: 'Low Risk' };
+function getRiskLabel(confidence: number | undefined, aiPercentage?: number): string {
+  if (confidence === undefined) return 'Unknown';
+  if (aiPercentage && aiPercentage > 60) return 'High Risk';
+  if (confidence < 40) return 'High Risk';
+  if (confidence < 70 || (aiPercentage && aiPercentage > 40)) return 'Medium Risk';
+  return 'Low Risk';
 }
 
 function generateInterviewQuestions(profile: {
@@ -93,30 +65,25 @@ function generateInterviewQuestions(profile: {
 }): string[] {
   const questions: string[] = [];
 
-  // Questions based on low-scoring skills
   const weakSkills = profile.skillAssessment?.filter(s => s.score < 6) || [];
   weakSkills.slice(0, 2).forEach(skill => {
     questions.push(`Their ${skill.metric} scored ${skill.score}/10. Ask them to explain a challenging ${skill.metric} problem they solved recently.`);
   });
 
-  // Questions based on development style concerns
   const styleIssues = profile.developmentStyle?.filter(s => s.score < 5) || [];
   styleIssues.slice(0, 1).forEach(style => {
     questions.push(`${style.metric} scored low (${style.score}/10). Ask about their typical development workflow and ${style.metric.toLowerCase()} practices.`);
   });
 
-  // Questions based on confidence issues
   if (profile.profileConfidence && profile.profileConfidence < 60) {
     questions.push(`Profile confidence is ${profile.profileConfidence}%. Ask them to walk you through their most significant project that may not be on GitHub.`);
   }
 
-  // Questions about top repos
   if (profile.topRepos && profile.topRepos.length > 0) {
     const topRepo = profile.topRepos[0];
     questions.push(`Ask them to explain the architecture decisions in ${topRepo.name} and what they would do differently today.`);
   }
 
-  // Generic fallback questions
   if (questions.length < 3) {
     questions.push(`Ask them to live code a small feature or debug a problem in their primary language.`);
     questions.push(`Ask them to explain how they approach learning new technologies and staying current.`);
@@ -125,19 +92,27 @@ function generateInterviewQuestions(profile: {
   return questions.slice(0, 5);
 }
 
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-2">
+        {children}
+      </div>
+      <div className="border-b border-[#eee] mb-4" />
+    </>
+  );
+}
+
 function HireConversionBar({ username }: { username: string }) {
   const { isSignedIn, signIn } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isSaved, setIsSaved] = useState(false);
 
-  // Reflect localStorage state on mount; update if the user navigates between profiles.
   useEffect(() => {
     setIsSaved(readShortlist().some((u) => u.toLowerCase() === username.toLowerCase()));
   }, [username]);
 
-  // Handle ?action=saved redirect coming back from OAuth: complete the save the
-  // user was promised when they clicked the CTA pre-auth.
   useEffect(() => {
     if (searchParams.get('action') !== 'saved') return;
     if (!isSignedIn) return;
@@ -147,7 +122,6 @@ function HireConversionBar({ username }: { username: string }) {
       toast.success(`@${username} added to your shortlist`);
       safePostHog.capture('hire_candidate_saved', { username, source: 'oauth_return' });
     }
-    // Strip the action param so a refresh doesn't re-trigger.
     const params = new URLSearchParams(searchParams.toString());
     params.delete('action');
     const qs = params.toString();
@@ -177,9 +151,9 @@ function HireConversionBar({ username }: { username: string }) {
   };
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-30 border-t border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 print:hidden">
+    <div className="fixed bottom-0 left-0 right-0 z-30 border-t border-[#eee] bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 print:hidden">
       <div className="max-w-4xl mx-auto px-4 py-3 flex flex-col sm:flex-row gap-2 sm:gap-3 items-stretch sm:items-center">
-        <div className="text-sm text-gray-600 hidden sm:block flex-1">
+        <div className="text-sm text-[#888] hidden sm:block flex-1">
           Like @{username}? Save them or find similar developers.
         </div>
         <div className="flex gap-2 sm:gap-3">
@@ -188,7 +162,7 @@ function HireConversionBar({ username }: { username: string }) {
             onClick={onSave}
             disabled={isSaved}
             data-testid="hire-save-candidate-btn"
-            className="flex-1 sm:flex-none"
+            className="flex-1 sm:flex-none border-[#111] text-[#111] hover:bg-[#111] hover:text-white"
           >
             {isSaved ? (
               <>
@@ -205,9 +179,8 @@ function HireConversionBar({ username }: { username: string }) {
           <Button
             onClick={onFindSimilar}
             data-testid="hire-find-similar-btn"
-            className="flex-1 sm:flex-none"
+            className="flex-1 sm:flex-none bg-[#111] hover:bg-[#333] text-white"
           >
-            <Users className="h-4 w-4 mr-2" />
             Find similar
           </Button>
         </div>
@@ -225,14 +198,16 @@ export function HiringReportClient({ username, initialData }: HiringReportClient
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-white p-8 max-w-4xl mx-auto space-y-6">
-        <div className="animate-pulse rounded-md bg-gray-200 h-8 w-48" />
-        <div className="animate-pulse rounded-md bg-gray-200 h-4 w-32" />
-        <div className="grid md:grid-cols-2 gap-4 mt-6">
-          <div className="animate-pulse rounded-md bg-gray-200 h-32 w-full" />
-          <div className="animate-pulse rounded-md bg-gray-200 h-32 w-full" />
-        </div>
-        <div className="animate-pulse rounded-md bg-gray-200 h-48 w-full" />
+      <div className="min-h-screen bg-white pt-12 pb-20">
+        <PageWidthContainer>
+          <div className="animate-pulse rounded-sm bg-[#eee] h-8 w-48 mb-3" />
+          <div className="animate-pulse rounded-sm bg-[#eee] h-4 w-32 mb-8" />
+          <div className="grid md:grid-cols-2 gap-4">
+            <div className="animate-pulse rounded-sm bg-[#eee] h-32 w-full" />
+            <div className="animate-pulse rounded-sm bg-[#eee] h-32 w-full" />
+          </div>
+          <div className="animate-pulse rounded-sm bg-[#eee] h-48 w-full mt-4" />
+        </PageWidthContainer>
       </div>
     );
   }
@@ -240,12 +215,13 @@ export function HiringReportClient({ username, initialData }: HiringReportClient
   if (error) {
     return (
       <div className="min-h-screen bg-white flex items-center justify-center">
-        <div className="text-center max-w-md">
-          <XCircle className="h-8 w-8 text-red-500 mx-auto mb-4" />
-          <h1 className="text-xl font-semibold text-gray-900 mb-2">Error loading profile</h1>
-          <p className="text-gray-500 mb-4">{error.message}</p>
+        <div className="text-center max-w-md px-4">
+          <h1 className="text-[31px] font-semibold text-[#111] tracking-tight leading-none mb-3">
+            Couldn&apos;t load profile
+          </h1>
+          <p className="text-base text-[#888] mb-6">{error.message}</p>
           <Link href="/hire">
-            <Button variant="outline">
+            <Button variant="outline" className="border-[#111] text-[#111] hover:bg-[#111] hover:text-white">
               <ArrowLeft className="h-4 w-4 mr-2" />
               Try another username
             </Button>
@@ -259,20 +235,21 @@ export function HiringReportClient({ username, initialData }: HiringReportClient
     return (
       <div className="min-h-screen bg-white flex items-center justify-center">
         <div className="text-center max-w-md px-4">
-          <AlertCircle className="h-8 w-8 text-amber-500 mx-auto mb-4" />
-          <h1 className="text-xl font-semibold text-gray-900 mb-2">No profile found</h1>
-          <p className="text-gray-500 mb-4">
-            We haven't analyzed this user yet. The profile needs to be generated first.
+          <h1 className="text-[31px] font-semibold text-[#111] tracking-tight leading-none mb-3">
+            No profile found
+          </h1>
+          <p className="text-base text-[#888] mb-6">
+            We haven&apos;t analyzed this user yet. The profile needs to be generated first.
           </p>
           <div className="flex flex-col gap-2">
             <Link href={`/${username}`}>
-              <Button className="w-full">
+              <Button className="w-full bg-[#111] hover:bg-[#333] text-white">
                 Generate profile on github.gg/{username}
                 <ExternalLink className="h-4 w-4 ml-2" />
               </Button>
             </Link>
             <Link href="/hire">
-              <Button variant="outline" className="w-full">
+              <Button variant="outline" className="w-full border-[#111] text-[#111] hover:bg-[#111] hover:text-white">
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to search
               </Button>
@@ -284,113 +261,99 @@ export function HiringReportClient({ username, initialData }: HiringReportClient
   }
 
   const profile = data.profile;
-  const risk = getRiskLevel(profile.profileConfidence);
+  const riskLabel = getRiskLabel(profile.profileConfidence);
   const interviewQuestions = generateInterviewQuestions(profile);
 
-  // Calculate red flags and green flags
   const redFlags: string[] = [];
   const greenFlags: string[] = [];
 
   if (profile.profileConfidence !== undefined) {
     if (profile.profileConfidence < 50) {
-      redFlags.push(`Low profile confidence (${profile.profileConfidence}%) - ${profile.confidenceReason || 'Limited visible work'}`);
+      redFlags.push(`Low profile confidence (${profile.profileConfidence}%) — ${profile.confidenceReason || 'limited visible work'}`);
     } else if (profile.profileConfidence >= 80) {
-      greenFlags.push(`High profile confidence (${profile.profileConfidence}%) - Strong GitHub presence`);
+      greenFlags.push(`High profile confidence (${profile.profileConfidence}%) — strong GitHub presence`);
     }
   }
 
-  // Check for weak skills
   const weakSkills = profile.skillAssessment?.filter(s => s.score < 5) || [];
   weakSkills.forEach(skill => {
     redFlags.push(`Weak ${skill.metric} (${skill.score}/10)`);
   });
 
-  // Check for strong skills
   const strongSkills = profile.skillAssessment?.filter(s => s.score >= 8) || [];
   strongSkills.slice(0, 3).forEach(skill => {
     greenFlags.push(`Strong ${skill.metric} (${skill.score}/10)`);
   });
 
-  // Check archetype
   if (profile.developerArchetype === 'Early Career Explorer') {
-    redFlags.push('Early career developer - may need mentorship');
+    redFlags.push('Early career developer — may need mentorship');
   } else if (profile.developerArchetype === 'Production Builder') {
-    greenFlags.push('Production-focused developer - ships complete work');
+    greenFlags.push('Production-focused developer — ships complete work');
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-4xl mx-auto px-4 py-6">
-          <div className="flex items-center justify-between mb-4">
-            <Link href="/hire" className="text-sm text-gray-500 hover:text-gray-900 flex items-center gap-1">
-              <ArrowLeft className="h-4 w-4" />
-              Back to search
-            </Link>
-            <a
-              href={`https://github.com/${username}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-gray-500 hover:text-gray-900 flex items-center gap-1"
-            >
-              View on GitHub
-              <ExternalLink className="h-4 w-4" />
-            </a>
-          </div>
+    <div className="min-h-screen bg-white pt-12 pb-32">
+      <PageWidthContainer>
+        <div className="flex items-center justify-between mb-6">
+          <Link href="/hire" className="text-sm text-[#888] hover:text-[#111] inline-flex items-center gap-1 transition-colors">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to search
+          </Link>
+          <a
+            href={`https://github.com/${username}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-[#888] hover:text-[#111] inline-flex items-center gap-1 transition-colors"
+          >
+            View on GitHub
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </div>
 
-          <div className="flex items-start justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900 mb-1">@{username}</h1>
-              <p className="text-gray-500">{profile.developerArchetype || 'Developer'}</p>
-            </div>
-            <div className={`px-3 py-1.5 rounded ${risk.bgColor}`}>
-              <span className={`font-medium ${risk.color}`}>{risk.label}</span>
-            </div>
+        <div className="flex items-start justify-between gap-4 mb-10">
+          <div className="min-w-0">
+            <h1 className="text-[31px] font-semibold text-[#111] tracking-tight leading-none mb-2">
+              @{username}
+            </h1>
+            <p className="text-base text-[#888]">{profile.developerArchetype || 'Developer'}</p>
+          </div>
+          <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase flex-shrink-0">
+            {riskLabel}
           </div>
         </div>
-      </div>
 
-      <div className="max-w-4xl mx-auto px-4 py-8">
         {/* Summary */}
-        <div className="bg-white border border-gray-200 p-6 mb-6">
-          <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-3">Summary</h2>
-          <p className="text-gray-700">{profile.summary}</p>
+        <section className="mb-10">
+          <SectionLabel>Summary</SectionLabel>
+          <p className="text-base text-[#111] leading-relaxed">{profile.summary}</p>
           {profile.scoreInterpretation && (
-            <p className="text-sm text-gray-500 mt-3 italic">{profile.scoreInterpretation}</p>
+            <p className="text-sm text-[#888] mt-3 italic">{profile.scoreInterpretation}</p>
           )}
-        </div>
+        </section>
 
         {/* Key Metrics */}
-        <div className="grid md:grid-cols-2 gap-4 mb-6">
-          {/* Profile Confidence */}
-          <div className="bg-white border border-gray-200 p-5">
-            <div className="flex items-center gap-2 mb-3">
-              <Shield className="h-5 w-5 text-gray-400" />
-              <h3 className="font-medium text-gray-900">Profile Confidence</h3>
-            </div>
-            <div className="flex items-baseline gap-2 mb-2">
-              <span className="text-3xl font-bold text-gray-900">
+        <section className="grid md:grid-cols-2 gap-10 mb-10">
+          <div>
+            <SectionLabel>Profile Confidence</SectionLabel>
+            <div className="flex items-baseline gap-1 mb-2">
+              <span className="text-[31px] font-semibold text-[#111] tracking-tight leading-none">
                 {profile.profileConfidence ?? 'N/A'}
               </span>
               {profile.profileConfidence !== undefined && (
-                <span className="text-gray-500">/ 100</span>
+                <span className="text-base text-[#aaa]">/100</span>
               )}
             </div>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-[#888]">
               {profile.confidenceReason || 'How well this GitHub represents their true skills'}
             </p>
           </div>
 
-          {/* Developer Type */}
-          <div className="bg-white border border-gray-200 p-5">
-            <div className="flex items-center gap-2 mb-3">
-              <User className="h-5 w-5 text-gray-400" />
-              <h3 className="font-medium text-gray-900">Developer Type</h3>
-            </div>
-            <div className="text-xl font-semibold text-gray-900 mb-2">
+          <div>
+            <SectionLabel>Developer Type</SectionLabel>
+            <div className="text-lg font-semibold text-[#111] mb-2">
               {profile.developerArchetype || 'Unknown'}
             </div>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-[#888]">
               {profile.developerArchetype === 'Research & Innovation' && 'Prioritizes exploration over polish'}
               {profile.developerArchetype === 'Production Builder' && 'Ships complete, tested projects'}
               {profile.developerArchetype === 'Open Source Contributor' && 'Focus on contributing to others projects'}
@@ -399,92 +362,74 @@ export function HiringReportClient({ username, initialData }: HiringReportClient
               {profile.developerArchetype === 'Early Career Explorer' && 'Building portfolio, learning'}
             </p>
           </div>
-        </div>
+        </section>
 
         {/* Flags */}
-        <div className="grid md:grid-cols-2 gap-4 mb-6">
-          {/* Red Flags */}
-          <div className="bg-white border border-gray-200 p-5">
-            <div className="flex items-center gap-2 mb-3">
-              <AlertTriangle className="h-5 w-5 text-red-500" />
-              <h3 className="font-medium text-gray-900">Red Flags</h3>
-            </div>
+        <section className="grid md:grid-cols-2 gap-10 mb-10">
+          <div>
+            <SectionLabel>Red Flags</SectionLabel>
             {redFlags.length > 0 ? (
               <ul className="space-y-2">
                 {redFlags.map((flag, idx) => (
-                  <li key={idx} className="flex items-start gap-2 text-sm">
-                    <XCircle className="h-4 w-4 text-red-400 mt-0.5 flex-shrink-0" />
-                    <span className="text-gray-700">{flag}</span>
+                  <li key={idx} className="text-sm text-[#666] flex gap-2">
+                    <span className="text-[#ccc]">−</span>
+                    <span>{flag}</span>
                   </li>
                 ))}
               </ul>
             ) : (
-              <p className="text-sm text-gray-500">No significant red flags detected</p>
+              <p className="text-sm text-[#aaa]">No significant red flags detected.</p>
             )}
           </div>
 
-          {/* Green Flags */}
-          <div className="bg-white border border-gray-200 p-5">
-            <div className="flex items-center gap-2 mb-3">
-              <CheckCircle className="h-5 w-5 text-emerald-500" />
-              <h3 className="font-medium text-gray-900">Green Flags</h3>
-            </div>
+          <div>
+            <SectionLabel>Green Flags</SectionLabel>
             {greenFlags.length > 0 ? (
               <ul className="space-y-2">
                 {greenFlags.map((flag, idx) => (
-                  <li key={idx} className="flex items-start gap-2 text-sm">
-                    <CheckCircle className="h-4 w-4 text-emerald-400 mt-0.5 flex-shrink-0" />
-                    <span className="text-gray-700">{flag}</span>
+                  <li key={idx} className="text-sm text-[#666] flex gap-2">
+                    <span className="text-[#ccc]">+</span>
+                    <span>{flag}</span>
                   </li>
                 ))}
               </ul>
             ) : (
-              <p className="text-sm text-gray-500">Generate a full profile for detailed signals</p>
+              <p className="text-sm text-[#aaa]">Generate a full profile for detailed signals.</p>
             )}
           </div>
-        </div>
+        </section>
 
-        {/* Skills Assessment */}
         {profile.skillAssessment && profile.skillAssessment.length > 0 && (
-          <div className="bg-white border border-gray-200 p-5 mb-6">
-            <div className="flex items-center gap-2 mb-4">
-              <GitBranch className="h-5 w-5 text-gray-400" />
-              <h3 className="font-medium text-gray-900">Skills Assessment</h3>
-            </div>
+          <section className="mb-10">
+            <SectionLabel>Skills Assessment</SectionLabel>
             <SkillAssessment skills={profile.skillAssessment} compact />
-          </div>
+          </section>
         )}
 
-        {/* Interview Questions */}
-        <div className="bg-white border border-gray-200 p-5 mb-6">
-          <div className="flex items-center gap-2 mb-4">
-            <MessageSquare className="h-5 w-5 text-gray-400" />
-            <h3 className="font-medium text-gray-900">Suggested Interview Questions</h3>
-          </div>
+        <section className="mb-10">
+          <SectionLabel>Suggested Interview Questions</SectionLabel>
           <ul className="space-y-3">
             {interviewQuestions.map((question, idx) => (
               <li key={idx} className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-gray-100 text-gray-600 text-sm flex items-center justify-center">
+                <span className="flex-shrink-0 w-6 h-6 border border-[#eee] text-[#888] text-xs font-mono flex items-center justify-center">
                   {idx + 1}
                 </span>
-                <span className="text-sm text-gray-700">{question}</span>
+                <span className="text-sm text-[#666] leading-relaxed">{question}</span>
               </li>
             ))}
           </ul>
-        </div>
+        </section>
 
-        {/* Top Repositories */}
         {profile.topRepos && profile.topRepos.length > 0 && (
-          <div className="bg-white border border-gray-200 p-5 mb-6">
-            <h3 className="font-medium text-gray-900 mb-4">Notable Repositories</h3>
+          <section className="mb-10">
+            <SectionLabel>Notable Repositories</SectionLabel>
             <TopRepos repos={profile.topRepos} compact username={username} />
-          </div>
+          </section>
         )}
 
-        {/* Secondary actions */}
-        <div className="flex flex-col sm:flex-row gap-3 mb-24 sm:mb-20">
+        <div className="flex flex-col sm:flex-row gap-3 mt-10">
           <Link href={`/${username}`} className="flex-1">
-            <Button variant="outline" className="w-full">
+            <Button variant="outline" className="w-full border-[#111] text-[#111] hover:bg-[#111] hover:text-white">
               View full profile on GG
               <ExternalLink className="h-4 w-4 ml-2" />
             </Button>
@@ -492,15 +437,13 @@ export function HiringReportClient({ username, initialData }: HiringReportClient
           <Button
             variant="outline"
             onClick={() => window.print()}
-            className="flex-1"
+            className="flex-1 border-[#111] text-[#111] hover:bg-[#111] hover:text-white"
           >
             Print / Save as PDF
           </Button>
         </div>
-      </div>
+      </PageWidthContainer>
 
-      {/* Conversion bar — sticks to the viewport bottom so it stays in view
-          after the user has read the report (the highest-intent moment). */}
       <HireConversionBar username={username} />
     </div>
   );

--- a/src/app/hire/match/page.tsx
+++ b/src/app/hire/match/page.tsx
@@ -3,15 +3,15 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { Checkbox } from '@/components/ui/checkbox';
 import { CandidateMatchCard } from '@/components/hire/CandidateMatchCard';
 import { trpc } from '@/lib/trpc/client';
 import { toast } from 'sonner';
-import { Search, Sparkles, Users, Filter, ArrowLeft, Github } from 'lucide-react';
+import { ArrowLeft, Github } from 'lucide-react';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth/client';
+import { PageWidthContainer } from '@/components/PageWidthContainer';
 
 const DRAFT_KEY = 'hire-match-draft-v1';
 
@@ -120,79 +120,61 @@ export default function HireMatchPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="bg-white border-b">
-        <div className="max-w-6xl mx-auto px-4 py-6">
-          <Link
-            href="/hire"
-            className="text-sm text-gray-500 hover:text-gray-900 flex items-center gap-1 mb-4"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back to Hire
-          </Link>
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-amber-100 rounded-lg">
-              <Sparkles className="h-6 w-6 text-amber-600" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">AI Job Matching</h1>
-              <p className="text-gray-500">
-                Paste a job description to find and rank candidates automatically
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+    <div className="min-h-screen bg-white pt-12 pb-20">
+      <PageWidthContainer>
+        <Link
+          href="/hire"
+          className="text-sm text-[#888] hover:text-[#111] inline-flex items-center gap-1 mb-6 transition-colors"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to Hire
+        </Link>
 
-      <div className="max-w-6xl mx-auto px-4 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <h1 className="text-[31px] font-semibold text-[#111] tracking-tight leading-none mb-2">
+          Match by Job Description
+        </h1>
+        <p className="text-base text-[#888] mb-10 max-w-2xl">
+          Paste a job description to find and rank candidates from analyzed developer profiles.
+        </p>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
           {/* Left: Job input */}
           <div className="lg:col-span-1">
-            <div className="bg-white rounded-lg border p-6 sticky top-8">
-              <Label htmlFor="job-description" className="text-base font-medium">
+            <div className="lg:sticky lg:top-8">
+              <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-2">
                 Job Description
-              </Label>
-              <p className="text-sm text-muted-foreground mb-3">
-                Paste your job listing or requirements
-              </p>
+              </div>
+              <div className="border-b border-[#eee] mb-4" />
 
               <Textarea
                 id="job-description"
-                placeholder="Paste your job description here...
-
-Include:
-- Required skills and experience
-- Tech stack preferences
-- Role responsibilities
-- Nice-to-haves"
+                placeholder="Paste your job description here…&#10;&#10;Include:&#10;- Required skills and experience&#10;- Tech stack preferences&#10;- Role responsibilities&#10;- Nice-to-haves"
                 value={jobDescription}
                 onChange={(e) => setJobDescription(e.target.value)}
-                className="min-h-[200px] mb-3"
+                className="min-h-[200px] mb-3 text-sm border-[#ddd] focus-visible:ring-0 focus-visible:border-[#111]"
               />
 
               <button
                 onClick={useExample}
-                className="text-xs text-blue-600 hover:underline mb-4 block"
+                className="text-xs text-[#888] hover:text-[#111] underline underline-offset-2 mb-6 block transition-colors"
               >
                 Use example job description
               </button>
 
-              {/* Filters toggle */}
               <button
                 onClick={() => setShowFilters(!showFilters)}
-                className="flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 mb-4"
+                className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-2 hover:text-[#111] transition-colors"
               >
-                <Filter className="h-4 w-4" />
                 {showFilters ? 'Hide Filters' : 'Show Filters'}
               </button>
+              <div className="border-b border-[#eee] mb-4" />
 
               {showFilters && (
-                <div className="space-y-4 mb-4 p-4 bg-gray-50 rounded-lg">
-                  {/* Confidence slider */}
+                <div className="space-y-6 mb-6">
                   <div>
-                    <Label className="text-sm">
-                      Minimum Profile Confidence: {minConfidence}%
-                    </Label>
+                    <div className="text-sm text-[#111] mb-2">
+                      Minimum profile confidence: <span className="font-mono text-[13px]">{minConfidence}%</span>
+                    </div>
                     <Slider
                       value={[minConfidence]}
                       onValueChange={([val]) => setMinConfidence(val)}
@@ -203,9 +185,8 @@ Include:
                     />
                   </div>
 
-                  {/* Archetype filters */}
                   <div>
-                    <Label className="text-sm mb-2 block">Developer Types</Label>
+                    <div className="text-sm text-[#111] mb-2">Developer types</div>
                     <div className="space-y-2">
                       {ARCHETYPES.map((archetype) => (
                         <div key={archetype} className="flex items-center gap-2">
@@ -216,7 +197,7 @@ Include:
                           />
                           <label
                             htmlFor={archetype}
-                            className="text-sm cursor-pointer"
+                            className="text-sm text-[#111] cursor-pointer"
                           >
                             {archetype}
                           </label>
@@ -232,13 +213,13 @@ Include:
                   <Button
                     onClick={handleSignInToMatch}
                     disabled={jobDescription.trim().length < 50}
-                    className="w-full"
+                    className="w-full bg-[#111] hover:bg-[#333] text-white"
                     data-testid="hire-match-signin"
                   >
                     <Github className="h-4 w-4 mr-2" />
                     Sign in with GitHub to match
                   </Button>
-                  <p className="text-xs text-muted-foreground mt-2 text-center">
+                  <p className="text-xs text-[#aaa] mt-2 text-center">
                     Your draft is saved — you&apos;ll land back here.
                   </p>
                 </>
@@ -246,17 +227,16 @@ Include:
                 <Button
                   onClick={handleSearch}
                   disabled={matchMutation.isPending || jobDescription.trim().length < 50 || authLoading}
-                  className={`w-full ${matchMutation.isPending ? 'animate-pulse' : ''}`}
+                  className={`w-full bg-[#111] hover:bg-[#333] text-white ${matchMutation.isPending ? 'animate-pulse' : ''}`}
                   data-testid="hire-match-submit"
                 >
-                  <Search className="h-4 w-4 mr-2" />
                   Find Candidates
                 </Button>
               )}
 
               {matchMutation.isPending && (
-                <p className="text-xs text-muted-foreground mt-2 text-center">
-                  This may take 30-60 seconds as we analyze each candidate
+                <p className="text-xs text-[#aaa] mt-2 text-center">
+                  This may take 30–60 seconds as each candidate is analyzed.
                 </p>
               )}
             </div>
@@ -265,50 +245,38 @@ Include:
           {/* Right: Results */}
           <div className="lg:col-span-2">
             {!matchMutation.data && !matchMutation.isPending && (
-              <div className="bg-white rounded-lg border p-12 text-center">
-                <Users className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">
-                  Find Your Perfect Candidates
-                </h3>
-                <p className="text-gray-500 max-w-md mx-auto">
-                  Paste a job description on the left and our AI will find and rank
-                  the best matching developers from our database.
+              <div className="border-t border-[#eee] pt-12 pb-16 text-center">
+                <p className="text-base text-[#aaa] max-w-md mx-auto">
+                  Paste a job description on the left and we&apos;ll rank developers from the analyzed pool by fit.
                 </p>
               </div>
             )}
 
             {matchMutation.isPending && (
-              <div className="bg-white rounded-lg border p-6 space-y-4">
-                <div className="animate-pulse rounded-md bg-gray-200 h-6 w-48" />
-                <div className="animate-pulse rounded-md bg-gray-200 h-24 w-full" />
-                <div className="animate-pulse rounded-md bg-gray-200 h-24 w-full" />
-                <div className="animate-pulse rounded-md bg-gray-200 h-24 w-full" />
+              <div className="space-y-4">
+                <div className="animate-pulse rounded-sm bg-[#eee] h-6 w-48" />
+                <div className="animate-pulse rounded-sm bg-[#eee] h-24 w-full" />
+                <div className="animate-pulse rounded-sm bg-[#eee] h-24 w-full" />
+                <div className="animate-pulse rounded-sm bg-[#eee] h-24 w-full" />
               </div>
             )}
 
             {matchMutation.data && (
               <div className="space-y-4">
-                {/* Results header */}
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h2 className="text-lg font-semibold text-gray-900">
-                      {matchMutation.data.candidates.length} Candidates Found
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                      Searched {matchMutation.data.totalSearched} profiles in{' '}
-                      {(matchMutation.data.searchTimeMs / 1000).toFixed(1)}s
-                    </p>
+                <div>
+                  <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-2">
+                    {matchMutation.data.candidates.length} Candidate{matchMutation.data.candidates.length === 1 ? '' : 's'} Found
                   </div>
+                  <div className="border-b border-[#eee] mb-4" />
+                  <p className="text-xs text-[#aaa] mb-6 font-mono">
+                    Searched {matchMutation.data.totalSearched} profiles in {(matchMutation.data.searchTimeMs / 1000).toFixed(1)}s
+                  </p>
                 </div>
 
-                {/* Candidate cards */}
                 {matchMutation.data.candidates.length === 0 ? (
-                  <div className="bg-white rounded-lg border p-8 text-center">
-                    <p className="text-gray-500">
-                      No candidates matched your criteria. Try adjusting your filters
-                      or using a different job description.
-                    </p>
-                  </div>
+                  <p className="text-base text-[#aaa] py-8 text-center">
+                    No candidates matched your criteria. Try adjusting filters or rewording the job description.
+                  </p>
                 ) : (
                   <div className="space-y-4">
                     {matchMutation.data.candidates.map((candidate) => (
@@ -334,7 +302,7 @@ Include:
             )}
           </div>
         </div>
-      </div>
+      </PageWidthContainer>
     </div>
   );
 }

--- a/src/app/hire/page.tsx
+++ b/src/app/hire/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { ArrowRight, Github, Sparkles } from 'lucide-react';
+import { ArrowRight, Github } from 'lucide-react';
 import Link from 'next/link';
 import { PageWidthContainer } from '@/components/PageWidthContainer';
 import DiscoverApp from '@/components/discover/DiscoverApp';
@@ -87,7 +87,6 @@ function HireHeader() {
           data-testid="hire-jd-match-link"
           className="inline-flex items-center justify-center gap-1.5 h-10 px-4 rounded-md border border-[#111] text-sm font-medium text-[#111] hover:bg-[#111] hover:text-white transition-colors whitespace-nowrap"
         >
-          <Sparkles className="h-4 w-4" />
           Match by job description
           <ArrowRight className="h-3.5 w-3.5" />
         </Link>

--- a/src/components/hire/CandidateMatchCard.tsx
+++ b/src/components/hire/CandidateMatchCard.tsx
@@ -1,10 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
-import { CheckCircle2, AlertCircle, DollarSign, Target, MessageSquare } from 'lucide-react';
 
 interface CandidateMatchCardProps {
   username: string;
@@ -32,21 +28,14 @@ function formatSalary(amount: number): string {
   return `$${amount}`;
 }
 
-function getFitColor(score: number): string {
-  if (score >= 80) return 'text-green-600 bg-green-50 border-green-200';
-  if (score >= 60) return 'text-amber-600 bg-amber-50 border-amber-200';
-  return 'text-red-600 bg-red-50 border-red-200';
-}
-
 function getFitLabel(score: number): string {
-  if (score >= 80) return 'Strong Match';
-  if (score >= 60) return 'Moderate Match';
-  return 'Weak Match';
+  if (score >= 80) return 'Strong';
+  if (score >= 60) return 'Moderate';
+  return 'Weak';
 }
 
 export function CandidateMatchCard({
   username,
-  summary,
   archetype,
   confidence,
   fitScore,
@@ -58,120 +47,113 @@ export function CandidateMatchCard({
   topSkills,
 }: CandidateMatchCardProps) {
   return (
-    <Card data-testid={`hire-candidate-${username}-card`} className="overflow-hidden hover:shadow-md transition-shadow">
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-3">
-              <Link
-                href={`/hire/${username}`}
-                className="text-lg font-semibold hover:text-blue-600 transition-colors truncate"
-              >
-                {username}
-              </Link>
-              <div className={`px-2 py-1 rounded-md text-sm font-medium border ${getFitColor(fitScore)}`}>
-                {fitScore}% Fit
-              </div>
-            </div>
-            {archetype && (
-              <div className="text-sm text-muted-foreground mt-1">{archetype}</div>
-            )}
+    <article
+      data-testid={`hire-candidate-${username}-card`}
+      className="border border-[#eee] hover:border-[#ccc] transition-colors p-6"
+    >
+      <header className="flex items-start justify-between gap-4 mb-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-3 flex-wrap">
+            <Link
+              href={`/hire/${username}`}
+              className="text-lg font-semibold text-[#111] hover:text-[#666] transition-colors truncate"
+            >
+              {username}
+            </Link>
+            <span className="font-mono text-[13px] text-[#888]">
+              <span className="font-semibold text-[#111]">{fitScore}</span>
+              <span className="text-[#ccc]">/100</span> · {getFitLabel(fitScore)} fit
+            </span>
           </div>
-          <div className="text-right flex-shrink-0">
-            <div className="flex items-center gap-1 text-sm text-muted-foreground">
-              <DollarSign className="h-4 w-4" />
-              <span>
-                {formatSalary(salaryRange.min)} - {formatSalary(salaryRange.max)}
-              </span>
-            </div>
-            <div className="text-xs text-muted-foreground mt-1">
-              {confidence}% profile confidence
-            </div>
+          {archetype && (
+            <div className="text-sm text-[#888] mt-1">{archetype}</div>
+          )}
+        </div>
+        <div className="text-right flex-shrink-0">
+          <div className="font-mono text-[13px] text-[#111]">
+            {formatSalary(salaryRange.min)}–{formatSalary(salaryRange.max)}
+          </div>
+          <div className="text-xs text-[#aaa] mt-1 font-mono">
+            {confidence}% confidence
           </div>
         </div>
-      </CardHeader>
+      </header>
 
-      <CardContent className="space-y-4">
-        {/* Fit reason */}
-        <p className="text-sm text-gray-600">{fitReason}</p>
+      <p className="text-sm text-[#666] mb-5 leading-relaxed">{fitReason}</p>
 
-        {/* Top skills */}
-        {topSkills.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {topSkills.map((skill) => (
-              <Badge key={skill.name} variant="secondary" className="text-xs">
-                {skill.name}
-                <span className="ml-1 text-muted-foreground">{skill.score}/10</span>
-              </Badge>
-            ))}
+      {topSkills.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-5">
+          {topSkills.map((skill) => (
+            <span
+              key={skill.name}
+              className="inline-flex items-baseline gap-1 px-2 py-0.5 border border-[#eee] text-xs text-[#111]"
+            >
+              {skill.name}
+              <span className="font-mono text-[11px] text-[#aaa]">{skill.score}/10</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-5">
+        <div>
+          <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-2">
+            Key Strengths
           </div>
-        )}
+          <div className="border-b border-[#eee] mb-3" />
+          <ul className="space-y-1.5">
+            {keyStrengths.slice(0, 3).map((strength, i) => (
+              <li key={i} className="text-sm text-[#666] flex gap-2">
+                <span className="text-[#ccc]">+</span>
+                <span>{strength}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
 
-        {/* Strengths and gaps grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Strengths */}
+        {potentialGaps.length > 0 && (
           <div>
-            <div className="flex items-center gap-2 text-sm font-medium text-green-700 mb-2">
-              <CheckCircle2 className="h-4 w-4" />
-              Key Strengths
+            <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-2">
+              Areas to Explore
             </div>
-            <ul className="space-y-1">
-              {keyStrengths.slice(0, 3).map((strength, i) => (
-                <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
-                  <span className="text-green-500 mt-1">+</span>
-                  <span>{strength}</span>
+            <div className="border-b border-[#eee] mb-3" />
+            <ul className="space-y-1.5">
+              {potentialGaps.slice(0, 3).map((gap, i) => (
+                <li key={i} className="text-sm text-[#666] flex gap-2">
+                  <span className="text-[#ccc]">−</span>
+                  <span>{gap}</span>
                 </li>
               ))}
             </ul>
           </div>
-
-          {/* Gaps */}
-          {potentialGaps.length > 0 && (
-            <div>
-              <div className="flex items-center gap-2 text-sm font-medium text-amber-700 mb-2">
-                <AlertCircle className="h-4 w-4" />
-                Areas to Explore
-              </div>
-              <ul className="space-y-1">
-                {potentialGaps.slice(0, 3).map((gap, i) => (
-                  <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
-                    <span className="text-amber-500 mt-1">-</span>
-                    <span>{gap}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-
-        {/* Interview focus */}
-        {interviewFocus.length > 0 && (
-          <div className="pt-3 border-t">
-            <div className="flex items-center gap-2 text-sm font-medium text-blue-700 mb-2">
-              <MessageSquare className="h-4 w-4" />
-              Interview Focus
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {interviewFocus.map((topic, i) => (
-                <Badge key={i} variant="outline" className="text-xs">
-                  {topic}
-                </Badge>
-              ))}
-            </div>
-          </div>
         )}
+      </div>
 
-        {/* View full report link */}
-        <div className="pt-2">
-          <Link
-            data-testid="hire-candidate-view-btn"
-            href={`/hire/${username}`}
-            className="text-sm text-blue-600 hover:underline"
-          >
-            View Full Hiring Report →
-          </Link>
+      {interviewFocus.length > 0 && (
+        <div className="pt-4 border-t border-[#eee] mb-5">
+          <div className="text-xs text-[#999] font-semibold tracking-[1.5px] uppercase mb-3">
+            Interview Focus
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {interviewFocus.map((topic, i) => (
+              <span
+                key={i}
+                className="inline-block px-2 py-0.5 border border-[#eee] text-xs text-[#666]"
+              >
+                {topic}
+              </span>
+            ))}
+          </div>
         </div>
-      </CardContent>
-    </Card>
+      )}
+
+      <Link
+        data-testid="hire-candidate-view-btn"
+        href={`/hire/${username}`}
+        className="text-sm text-[#111] hover:text-[#666] transition-colors underline underline-offset-2"
+      >
+        View full hiring report →
+      </Link>
+    </article>
   );
 }


### PR DESCRIPTION
## Summary

The whole /hire section had drifted off-theme: amber Sparkles icon-box headers, \`bg-gray-50\` backgrounds, blue links, colored fit/risk badges, shadcn \`Card\`-in-\`Card\` layouts. Nothing like the rest of the site, which is minimal black-on-white tables + uppercase-tracked section labels (see \`MarkdownCardRenderer\`, \`ReposClientView\`).

## What changed

- \`/hire\` landing — kill the Sparkles icon on the JD-match button
- \`/hire/match\` — full rewrite into site theme: \`PageWidthContainer\`, the standard \`text-[31px]\` h1, uppercase tracked section labels, hex grays, no Sparkles/amber/colored card boxes, no blue links
- \`/hire/[username]\` HiringReportClient — full rewrite same treatment: drop \`bg-gray-50\`, drop the colored risk/red-flag/green-flag boxes, drop the \`Card\` primitives, drop icons in section headers
- \`CandidateMatchCard\` — drop \`Card\`/\`CardHeader\`/\`CardContent\`/\`Badge\`/\`Progress\`, replace colored fit-score badge with the same mono treatment used elsewhere

## Test plan

- [ ] \`/hire\` — JD-match button has no icon; rest of page unchanged
- [ ] \`/hire/match\` — site-themed page, results render with mono candidate cards
- [ ] \`/hire/{user}\` for a known analyzed user — sections render with uppercase tracked labels and thin underline separators; no amber/red/emerald backgrounds; sticky conversion bar at bottom uses theme buttons
- [ ] Print stylesheet still readable (the \`print:hidden\` on the conversion bar still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)