### PR TITLE
fix(map): pointer offset that grew linearly with X after zoom/resize

### DIFF
--- a/src/components/discover/SemanticMap.tsx
+++ b/src/components/discover/SemanticMap.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import DeckGL from '@deck.gl/react';
 import { ScatterplotLayer } from '@deck.gl/layers';
 import { OrthographicView } from '@deck.gl/core';
@@ -59,6 +59,31 @@ export function SemanticMap({
   );
   const [hovered, setHovered] = useState<{ point: SemanticMapPoint; x: number; y: number } | null>(null);
   const [clicked, setClicked] = useState<Set<string>>(() => new Set());
+
+  // Pass explicit width/height to DeckGL based on the container's actual size,
+  // and recompute via ResizeObserver. Without this, DeckGL's internal viewport
+  // can latch onto a stale CSS pixel size — and picking projects screen ↔ world
+  // through that stale width, so the cursor↔picked offset grows linearly with X
+  // (zero on the left edge, large on the right). Reproduces reliably when the
+  // canvas resizes after first paint (responsive layout shifts, container
+  // measurement after a sidebar opens/closes, etc.).
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      setSize((prev) => {
+        if (prev && prev.width === rect.width && prev.height === rect.height) return prev;
+        return { width: rect.width, height: rect.height };
+      });
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   const visible = useMemo(
     () => points.filter(p => enabled.has(p.archetype ?? 'Unknown')),
@@ -136,7 +161,7 @@ export function SemanticMap({
 
   if (points.length === 0) {
     return (
-      <div style={containerStyle} className="flex items-center justify-center">
+      <div ref={containerRef} style={containerStyle} className="flex items-center justify-center">
         <div className="text-center px-6">
           <p className="text-sm text-slate-600 mb-1">No projections yet.</p>
           <p className="text-xs text-slate-500">
@@ -148,7 +173,7 @@ export function SemanticMap({
   }
 
   return (
-    <div style={containerStyle}>
+    <div ref={containerRef} style={containerStyle}>
       {showLegend && (
         <div className="absolute top-3 right-3 z-10 bg-white/90 backdrop-blur p-3 rounded-md shadow-sm border text-xs space-y-1.5 max-w-xs">
           <div className="font-medium text-slate-700 mb-1.5">Archetypes</div>
@@ -181,14 +206,26 @@ export function SemanticMap({
         {visible.length.toLocaleString()} / {points.length.toLocaleString()} developers · dot size = confidence
       </div>
 
-      <DeckGL
-        views={new OrthographicView({ id: 'ortho' })}
-        initialViewState={{ target: [bounds.cx, bounds.cy, 0], zoom: bounds.zoom }}
-        controller={true}
-        layers={[layer]}
-        onClick={handleClick}
-        style={{ position: 'absolute', inset: '0' }}
-      />
+      {size && (
+        <DeckGL
+          views={new OrthographicView({ id: 'ortho' })}
+          initialViewState={{ target: [bounds.cx, bounds.cy, 0], zoom: bounds.zoom }}
+          controller={true}
+          layers={[layer]}
+          onClick={handleClick}
+          width={size.width}
+          height={size.height}
+          // Clear the tooltip whenever the view changes (scroll-wheel zoom, drag
+          // pan). Otherwise the tooltip stays anchored to the pre-zoom info.x/y
+          // and shows the pre-zoom dot's data until the user moves the mouse 1px.
+          onViewStateChange={({ interactionState }) => {
+            if (interactionState.isZooming || interactionState.isPanning) {
+              setHovered(null);
+            }
+          }}
+          style={{ position: 'absolute', inset: '0' }}
+        />
+      )}
 
       {hovered && (
         <div


### PR DESCRIPTION
## Symptom

On the semantic map (\`SemanticMap\`), after scroll-zooming inside the canvas — or after the container otherwise resizes — hover/click hit-testing was offset:

- 0 offset on the left edge
- Increasingly exaggerated offset toward the right edge

That linear-with-X pattern is the signature of a stale viewport width: DeckGL's picking projection maps screen ↔ world through the canvas's assumed CSS width, and when that assumed width is smaller than the actually-rendered width, the error scales with how far right the cursor is.

## Fix

1. Drive DeckGL's \`width\`/\`height\` explicitly from a \`ResizeObserver\` on the container, instead of letting deck auto-measure. The component waits for the first measurement before mounting DeckGL, so the picking projection is never seeded with a stale or zero size, and it stays in sync if the container later resizes.

2. Clear the tooltip when the view state changes during a zoom or pan interaction. Without this the tooltip lingers at the pre-zoom \`info.x/info.y\` and shows the pre-zoom dot's data until the next mouse-move event fires.

## Test plan

- [ ] On \`/hire\` map view, scroll-zoom and verify hovering matches the dot under the cursor across the entire canvas (especially the right edge)
- [ ] Resize the window or open/close a sidebar — picking should stay aligned after the resize
- [ ] Scroll-zoom mid-hover — the tooltip clears and re-renders correctly on next mouse move

🤖 Generated with [Claude Code](https://claude.com/claude-code)